### PR TITLE
Implement standard FromStr trait for HashAlgorithm

### DIFF
--- a/src/assertion.rs
+++ b/src/assertion.rs
@@ -188,7 +188,7 @@ impl PartialEq for Assertion {
 /// Helper function to generate assertion labels with optional indexing (for multiple instances of the same type).
 pub fn generate_assertion_label(base_label: &str, index: Option<u32>) -> String {
     if let Some(idx) = index {
-        format!("{}__{}", base_label, idx)
+        format!("{base_label}__{idx}")
     } else {
         base_label.to_string()
     }

--- a/src/datetime_wrapper.rs
+++ b/src/datetime_wrapper.rs
@@ -90,10 +90,10 @@ pub fn validate_datetime(datetime: &OffsetDateTimeWrapper) -> Result<(), String>
 
 /// Reads the contents of a PEM file into a `Vec<u8>`.
 fn load_pem_file(path: &str) -> Result<Vec<u8>, String> {
-    let mut file = File::open(path).map_err(|e| format!("Failed to open PEM file: {}", e))?;
+    let mut file = File::open(path).map_err(|e| format!("Failed to open PEM file: {e}"))?;
     let mut contents = Vec::new();
     file.read_to_end(&mut contents)
-        .map_err(|e| format!("Failed to read PEM file: {}", e))?;
+        .map_err(|e| format!("Failed to read PEM file: {e}"))?;
     Ok(contents)
 }
 
@@ -114,29 +114,26 @@ pub fn verify_tsa_token(tsa_token_path: &str, tsa_public_key_path: &str) -> Resu
     // Check if files exist first
     if !std::path::Path::new(tsa_token_path).exists() {
         return Err(format!(
-            "[TSA] Token file not found at path: {}",
-            tsa_token_path
+            "[TSA] Token file not found at path: {tsa_token_path}"
         ));
     }
 
     if !std::path::Path::new(tsa_public_key_path).exists() {
         return Err(format!(
-            "[TSA] Public key file not found at path: {}",
-            tsa_public_key_path
+            "[TSA] Public key file not found at path: {tsa_public_key_path}"
         ));
     }
 
     let mut tsa_token_file = File::open(tsa_token_path).map_err(|e| {
         format!(
-            "[TSA] Failed to open token file '{}': {}",
-            tsa_token_path, e
+            "[TSA] Failed to open token file '{tsa_token_path}': {e}"
         )
     })?;
 
     let mut tsa_token_data = Vec::new();
     tsa_token_file
         .read_to_end(&mut tsa_token_data)
-        .map_err(|e| format!("[TSA] Failed to read token file: {}", e))?;
+        .map_err(|e| format!("[TSA] Failed to read token file: {e}"))?;
 
     if tsa_token_data.is_empty() {
         return Err("[TSA] TSA token file is empty".to_string());
@@ -144,18 +141,16 @@ pub fn verify_tsa_token(tsa_token_path: &str, tsa_public_key_path: &str) -> Resu
 
     let mut cms = CmsContentInfo::from_der(&tsa_token_data).map_err(|e| {
         format!(
-            "[TSA] Failed to parse CMS structure: {} (invalid DER format)",
-            e
+            "[TSA] Failed to parse CMS structure: {e} (invalid DER format)"
         )
     })?;
 
     let pem_data = load_pem_file(tsa_public_key_path)
-        .map_err(|e| format!("[TSA] Failed to load public key: {}", e))?;
+        .map_err(|e| format!("[TSA] Failed to load public key: {e}"))?;
 
     let tsa_public_key = X509::stack_from_pem(&pem_data).map_err(|e| {
         format!(
-            "[TSA] Failed to parse public key (invalid PEM format): {}",
-            e
+            "[TSA] Failed to parse public key (invalid PEM format): {e}"
         )
     })?;
 
@@ -171,7 +166,7 @@ pub fn verify_tsa_token(tsa_token_path: &str, tsa_public_key_path: &str) -> Resu
         None, // No X509 store reference
         CMSOptions::empty(),
     )
-    .map_err(|e| format!("[TSA] Token signature verification failed: {}", e))?;
+    .map_err(|e| format!("[TSA] Token signature verification failed: {e}"))?;
 
     Ok(())
 }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -125,17 +125,17 @@ impl Ingredient {
         if let Some(key) = public_key {
             // Perform verification with the provided public key (dummy implementation)
             let mut verifier = Verifier::new(openssl::hash::MessageDigest::sha256(), key)
-                .map_err(|e| format!("Failed to create verifier: {}", e))?;
+                .map_err(|e| format!("Failed to create verifier: {e}"))?;
 
             // This is a placeholder for the actual data that would be verified
             let data_to_verify = b"example data";
 
             verifier
                 .update(data_to_verify)
-                .map_err(|e| format!("Failed to update verifier: {}", e))?;
+                .map_err(|e| format!("Failed to update verifier: {e}"))?;
             if verifier
                 .verify(&[])
-                .map_err(|e| format!("Failed to verify: {}", e))?
+                .map_err(|e| format!("Failed to verify: {e}"))?
             {
                 Ok(())
             } else {
@@ -172,16 +172,16 @@ impl Verifiable for Ingredient {
         if let Some(key) = public_key {
             // Perform signature verification using the public key
             let mut verifier = Verifier::new(openssl::hash::MessageDigest::sha256(), key)
-                .map_err(|e| format!("Failed to create verifier: {}", e))?;
+                .map_err(|e| format!("Failed to create verifier: {e}"))?;
 
             let data_to_verify = b"example data"; // Replace with actual data to verify
             verifier
                 .update(data_to_verify)
-                .map_err(|e| format!("Failed to update verifier: {}", e))?;
+                .map_err(|e| format!("Failed to update verifier: {e}"))?;
 
             if verifier
                 .verify(&[])
-                .map_err(|e| format!("Failed to verify: {}", e))?
+                .map_err(|e| format!("Failed to verify: {e}"))?
             {
                 Ok(())
             } else {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -183,7 +183,7 @@ pub fn validate_manifest_timestamp(datetime: &OffsetDateTimeWrapper) -> Result<(
 pub fn validate_manifest_structure(manifest_bytes: &[u8]) -> Result<(), String> {
     // Parse the manifest JSON
     let manifest: Value = serde_json::from_slice(manifest_bytes)
-        .map_err(|e| format!("Failed to parse manifest JSON: {}", e))?;
+        .map_err(|e| format!("Failed to parse manifest JSON: {e}"))?;
 
     // Ensure it has required fields (e.g., claim, instance_id, ingredients)
     if manifest.get("claim").is_none() {
@@ -227,7 +227,7 @@ pub fn validate_linked_manifest(
 
     let manifest_bytes = response
         .bytes()
-        .map_err(|e| format!("[LinkedManifest] Failed to read manifest response: {}", e))?;
+        .map_err(|e| format!("[LinkedManifest] Failed to read manifest response: {e}"))?;
 
     if manifest_bytes.is_empty() {
         return Err("[LinkedManifest] Received empty manifest data".to_string());
@@ -246,27 +246,27 @@ pub fn validate_linked_manifest(
 
     // Validate the manifest structure
     validate_manifest_structure(&manifest_bytes)
-        .map_err(|e| format!("[LinkedManifest] Invalid manifest structure: {}", e))?;
+        .map_err(|e| format!("[LinkedManifest] Invalid manifest structure: {e}"))?;
 
     // Validate the manifest signature
     let signature = extract_signature_from_manifest(&manifest_bytes)
-        .map_err(|e| format!("[LinkedManifest] Failed to extract signature: {}", e))?;
+        .map_err(|e| format!("[LinkedManifest] Failed to extract signature: {e}"))?;
 
     validate_manifest_signature(&manifest_bytes, &signature, public_key)
-        .map_err(|e| format!("[LinkedManifest] Signature validation failed: {}", e))?;
+        .map_err(|e| format!("[LinkedManifest] Signature validation failed: {e}"))?;
 
     Ok(())
 }
 
 fn extract_signature_from_manifest(manifest_bytes: &[u8]) -> Result<Vec<u8>, String> {
     let manifest: Manifest = serde_json::from_slice(manifest_bytes)
-        .map_err(|e| format!("Failed to parse manifest JSON: {}", e))?;
+        .map_err(|e| format!("Failed to parse manifest JSON: {e}"))?;
 
     // Check if claim_v2 is present
     if let Some(claim_v2) = manifest.claim_v2 {
         if let Some(signature) = claim_v2.signature {
             let signature_bytes = base64::decode(signature)
-                .map_err(|e| format!("Failed to decode signature: {}", e))?;
+                .map_err(|e| format!("Failed to decode signature: {e}"))?;
             return Ok(signature_bytes);
         } else {
             return Err("Signature field is missing in claim_v2.".to_string());
@@ -275,7 +275,7 @@ fn extract_signature_from_manifest(manifest_bytes: &[u8]) -> Result<Vec<u8>, Str
 
     if let Some(signature) = manifest.claim.signature {
         let signature_bytes =
-            base64::decode(signature).map_err(|e| format!("Failed to decode signature: {}", e))?;
+            base64::decode(signature).map_err(|e| format!("Failed to decode signature: {e}"))?;
         Ok(signature_bytes)
     } else {
         Err("Signature field is missing in claim.".to_string())
@@ -289,17 +289,17 @@ pub fn validate_manifest_signature(
 ) -> Result<(), String> {
     // Create a verifier with the public key
     let mut verifier = Verifier::new(openssl::hash::MessageDigest::sha256(), public_key)
-        .map_err(|e| format!("Failed to create verifier: {}", e))?;
+        .map_err(|e| format!("Failed to create verifier: {e}"))?;
 
     // Update the verifier with the manifest data
     verifier
         .update(manifest_bytes)
-        .map_err(|e| format!("Failed to update verifier: {}", e))?;
+        .map_err(|e| format!("Failed to update verifier: {e}"))?;
 
     // Verify the signature
     if verifier
         .verify(signature)
-        .map_err(|e| format!("Failed to verify signature: {}", e))?
+        .map_err(|e| format!("Failed to verify signature: {e}"))?
     {
         Ok(())
     } else {

--- a/tests/test_dataset.rs
+++ b/tests/test_dataset.rs
@@ -6,7 +6,6 @@ use atlas_c2pa_lib::claim::ClaimV2; // Using ClaimV2
 use atlas_c2pa_lib::datetime_wrapper::OffsetDateTimeWrapper;
 use atlas_c2pa_lib::ingredient::{Ingredient, IngredientData};
 use atlas_c2pa_lib::manifest::Manifest;
-use hex;
 use mockito::mock;
 use openssl::sha::sha256;
 use std::fs;
@@ -15,25 +14,23 @@ use time::OffsetDateTime;
 fn test_dataset_manifest_creation_v2() {
     let claim_generator = "c2pa-ml/0.1.0".to_string();
 
-    let file_paths = vec![
-        "tests/test_data/t10k-images-idx3-ubyte.gz",
+    let file_paths = ["tests/test_data/t10k-images-idx3-ubyte.gz",
         "tests/test_data/t10k-labels-idx1-ubyte.gz",
-        "tests/test_data/train-labels-idx1-ubyte.gz",
-    ];
+        "tests/test_data/train-labels-idx1-ubyte.gz"];
 
     let mut ingredients = vec![];
 
     for (i, file_path) in file_paths.iter().enumerate() {
         let file_content = fs::read(file_path).expect("Failed to read test file");
 
-        let mock = mock("GET", format!("/dataset_file_{}", i).as_str())
+        let mock = mock("GET", format!("/dataset_file_{i}").as_str())
             .with_status(200)
             .with_header("content-type", "application/octet-stream")
             .with_body(file_content.clone())
             .create();
 
         let ingredient_data = IngredientData {
-            url: mockito::server_url() + &format!("/dataset_file_{}", i),
+            url: mockito::server_url() + &format!("/dataset_file_{i}"),
             alg: "sha256".to_string(),
             hash: "".to_string(),
             data_types: vec![AssetType::Dataset],

--- a/tests/test_linking_ingredients.rs
+++ b/tests/test_linking_ingredients.rs
@@ -3,10 +3,8 @@ use atlas_c2pa_lib::claim::ClaimV2;
 use atlas_c2pa_lib::datetime_wrapper::OffsetDateTimeWrapper;
 use atlas_c2pa_lib::ingredient::{Ingredient, IngredientData, LinkedIngredient};
 use atlas_c2pa_lib::manifest::Manifest;
-use hex;
 use mockito::mock;
 use openssl::sha::sha256;
-use reqwest;
 use time::OffsetDateTime;
 
 #[test]
@@ -96,7 +94,7 @@ fn test_ingredient_linking_with_verification() {
     // Request the linked ingredient via HTTP mock
     let client = reqwest::blocking::Client::new();
     let response = client
-        .get(&ingredient.data.linked_ingredient_url.unwrap())
+        .get(ingredient.data.linked_ingredient_url.unwrap())
         .send()
         .expect("Failed to request linked ingredient");
 
@@ -127,7 +125,7 @@ fn test_ingredient_linking_with_verification() {
         .expect("Failed to read main ingredient body");
 
     // Print the main body for debugging purposes
-    println!("Main Ingredient Response Body: {}", main_body);
+    println!("Main Ingredient Response Body: {main_body}");
 
     // Validate the main ingredient mock was called
     ingredient_mock.assert();

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -6,7 +6,6 @@ use atlas_c2pa_lib::claim::ClaimV2; // Updated to use ClaimV2
 use atlas_c2pa_lib::datetime_wrapper::OffsetDateTimeWrapper;
 use atlas_c2pa_lib::ingredient::{Ingredient, IngredientData};
 use atlas_c2pa_lib::manifest::Manifest;
-use hex;
 use mockito::mock;
 use openssl::sha::sha256;
 use std::fs;

--- a/tests/test_manifest_cross_ref.rs
+++ b/tests/test_manifest_cross_ref.rs
@@ -6,7 +6,6 @@ use atlas_c2pa_lib::claim::ClaimV2;
 use atlas_c2pa_lib::datetime_wrapper::OffsetDateTimeWrapper;
 use atlas_c2pa_lib::ingredient::{Ingredient, IngredientData};
 use atlas_c2pa_lib::manifest::{CrossReference, Manifest};
-use hex;
 use mockito::mock;
 use openssl::sha::sha256;
 use time::OffsetDateTime;
@@ -129,7 +128,7 @@ fn test_cross_manifest_linking() {
     let manifest_json = serde_json::to_string(&manifest).unwrap();
     let _manifest_hash = hex::encode(sha256(manifest_json.as_bytes()));
 
-    println!("CrossReference Hash: {}", linked_manifest_hash);
+    println!("CrossReference Hash: {linked_manifest_hash}");
 
     let client = reqwest::blocking::Client::new();
     let response = client
@@ -139,7 +138,7 @@ fn test_cross_manifest_linking() {
 
     assert_eq!(response.status(), 200);
     let body = response.text().expect("Failed to read response body");
-    println!("Response Body: {}", body);
+    println!("Response Body: {body}");
 
     let known_manifest_hash = "8337441bdec617f12215056d9440f35fe3162fa569482f6454d4ccf5cc17d473";
     assert_eq!(

--- a/tests/test_ml_types.rs
+++ b/tests/test_ml_types.rs
@@ -2,7 +2,6 @@ use atlas_c2pa_lib::ml::assertions::MLModelAssertion;
 use atlas_c2pa_lib::ml::types::{
     DatasetInfo, MLFramework, Metric, ModelFormat, ModelInfo, Parameter, TrainingInfo,
 };
-use serde_json;
 
 #[test]
 fn test_model_info_creation() {
@@ -132,8 +131,7 @@ fn test_serialization() {
 
 #[test]
 fn test_training_metrics() {
-    let metrics = vec![
-        Metric {
+    let metrics = [Metric {
             name: "accuracy".to_string(),
             value: 0.95,
         },
@@ -144,8 +142,7 @@ fn test_training_metrics() {
         Metric {
             name: "f1_score".to_string(),
             value: 0.89,
-        },
-    ];
+        }];
 
     assert_eq!(metrics.len(), 3);
     assert!(metrics[0].value >= 0.0 && metrics[0].value <= 1.0);


### PR DESCRIPTION
Replace custom from_str method with standard FromStr trait implementation to resolve clippy warning and follow Rust conventions.
