### PR TITLE
Update dependencies: mockito 1.7.0, base64 modern API + github actions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ serde_json = "1.0"
 url = { version = "2.5.4", features = ["serde"] }
 uuid = { version = "1.10.1", features = ["v4"] }
 time = { version = "0.3.36", features = ["serde"] }
-serde_with = { version = "2", features = ["time_0_3"] }
+serde_with = { version = "3", features = ["time_0_3"] }
 reqwest = { version = "0.12.5", features = ["blocking"] }
 openssl = "0.10.72"
 openssl-sys = "0.9.103"
 ring = "0.17.12"
 coset = "^0.3.5"
 hex = "0.4"
-base64 = "0.13"
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-mockito = "0.31.0"
+mockito = "1.7.0"

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -95,6 +95,7 @@ use crate::claim::{validate_claim_v2, ClaimV2};
 pub use crate::cross_reference::CrossReference;
 use crate::datetime_wrapper::OffsetDateTimeWrapper;
 use crate::ingredient::{validate_ingredient, Ingredient};
+use base64::{engine::general_purpose, Engine as _};
 use openssl::pkey::PKey;
 use openssl::sign::Verifier;
 use serde::{Deserialize, Serialize};
@@ -265,7 +266,8 @@ fn extract_signature_from_manifest(manifest_bytes: &[u8]) -> Result<Vec<u8>, Str
     // Check if claim_v2 is present
     if let Some(claim_v2) = manifest.claim_v2 {
         if let Some(signature) = claim_v2.signature {
-            let signature_bytes = base64::decode(signature)
+            let signature_bytes = general_purpose::STANDARD
+                .decode(signature)
                 .map_err(|e| format!("Failed to decode signature: {e}"))?;
             return Ok(signature_bytes);
         } else {
@@ -274,8 +276,9 @@ fn extract_signature_from_manifest(manifest_bytes: &[u8]) -> Result<Vec<u8>, Str
     }
 
     if let Some(signature) = manifest.claim.signature {
-        let signature_bytes =
-            base64::decode(signature).map_err(|e| format!("Failed to decode signature: {e}"))?;
+        let signature_bytes = general_purpose::STANDARD
+            .decode(signature)
+            .map_err(|e| format!("Failed to decode signature: {e}"))?;
         Ok(signature_bytes)
     } else {
         Err("Signature field is missing in claim.".to_string())

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -2,31 +2,33 @@ use atlas_c2pa_lib::assertion::{
     Action, ActionAssertion, Assertion, Author, CreativeWorkAssertion,
 };
 use atlas_c2pa_lib::asset_type::AssetType;
-use atlas_c2pa_lib::claim::ClaimV2; // Updated to use ClaimV2
+use atlas_c2pa_lib::claim::ClaimV2;
 use atlas_c2pa_lib::datetime_wrapper::OffsetDateTimeWrapper;
 use atlas_c2pa_lib::ingredient::{Ingredient, IngredientData};
 use atlas_c2pa_lib::manifest::Manifest;
-use mockito::mock;
+use mockito::Server;
 use openssl::sha::sha256;
 use std::fs;
 use time::OffsetDateTime;
 
 #[test]
 fn test_manifest_creation_v2() {
+    let mut server = Server::new(); // Create a new mock server
     let claim_generator = "c2pa-ml/0.1.0".to_string();
 
     let file_path = "tests/test_data/model.bin";
     let file_content = fs::read(file_path).expect("Failed to read test file");
 
     // Mock the server to expect a GET request to /model.file
-    let mock = mock("GET", "/model.file")
+    let mock = server
+        .mock("GET", "/model.file")
         .with_status(200)
         .with_header("content-type", "application/octet-stream")
         .with_body(file_content.clone())
         .create();
 
     let ingredient_data = IngredientData {
-        url: mockito::server_url() + "/model.file",
+        url: server.url() + "/model.file",
         alg: "sha256".to_string(),
         hash: "".to_string(),
         data_types: vec![AssetType::ModelOpenVino],


### PR DESCRIPTION
**Changes:** 
- Migrate mockito to 1.7.0:
- Migrate base64 to 0.22 and fix deprecation warnings
- Update serde_with  to version 3
- Update GitHub actions to the latest versions