### PR TITLE
Add PartialEq derive to HashAlgorithm enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atlas-c2pa-lib" 
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A Rust library for creating, signing, and verifying machine learning assets with C2PA"
 authors = ["Intel Labs"]

--- a/src/cose.rs
+++ b/src/cose.rs
@@ -160,7 +160,7 @@ use openssl::sign::{Signer, Verifier};
 use std::str::FromStr;
 
 /// Supported hash algorithms for COSE signing and verification
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum HashAlgorithm {
     /// SHA-256 hash algorithm (256-bit)
     Sha256,


### PR DESCRIPTION
Add PartialEq derive to HashAlgorithm enum to enable direct comparison between algorithm variants. This is needed for signature verification logic where we need to ensure the signing and verification algorithms match.