### PR TITLE
Bump Rust edition from 2021 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlas-c2pa-lib" 
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "A Rust library for creating, signing, and verifying machine learning assets with C2PA"
 authors = ["Intel Labs"]
 license = "MIT OR Apache-2.0"

--- a/src/assertion.rs
+++ b/src/assertion.rs
@@ -356,7 +356,7 @@ fn validate_hash_assertion(hash_assertion: &HashAssertion) -> Result<(), String>
             return Err(format!(
                 "[HashAssertion] Unsupported hashing algorithm: '{}'. Expected one of: sha256, sha384, sha512",
                 hash_assertion.algorithm
-            ))
+            ));
         }
     }
 

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -71,11 +71,11 @@
 //!     is_active: true,
 //! };
 //! ```
-use crate::assertion::validate_assertion;
 use crate::assertion::Assertion;
+use crate::assertion::validate_assertion;
 use crate::ingredient::validate_ingredient;
 
-use crate::datetime_wrapper::{validate_datetime, OffsetDateTimeWrapper};
+use crate::datetime_wrapper::{OffsetDateTimeWrapper, validate_datetime};
 use crate::ingredient::Ingredient;
 use serde::{Deserialize, Serialize};
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -91,11 +91,11 @@
 //! // let validation_result = validate_linked_manifest(&cross_ref, &public_key);
 //! ```
 use crate::assertion::validate_assertion;
-use crate::claim::{validate_claim_v2, ClaimV2};
+use crate::claim::{ClaimV2, validate_claim_v2};
 pub use crate::cross_reference::CrossReference;
 use crate::datetime_wrapper::OffsetDateTimeWrapper;
-use crate::ingredient::{validate_ingredient, Ingredient};
-use base64::{engine::general_purpose, Engine as _};
+use crate::ingredient::{Ingredient, validate_ingredient};
+use base64::{Engine as _, engine::general_purpose};
 use openssl::pkey::PKey;
 use openssl::sign::Verifier;
 use serde::{Deserialize, Serialize};

--- a/tests/test_do_not_train_assertion.rs
+++ b/tests/test_do_not_train_assertion.rs
@@ -2,8 +2,8 @@ use atlas_c2pa_lib::assertion::Assertion;
 use atlas_c2pa_lib::assertion::DoNotTrainAssertion;
 use atlas_c2pa_lib::claim::ClaimV2;
 use atlas_c2pa_lib::datetime_wrapper::OffsetDateTimeWrapper;
-use atlas_c2pa_lib::manifest::validate_manifest;
 use atlas_c2pa_lib::manifest::Manifest;
+use atlas_c2pa_lib::manifest::validate_manifest;
 use time::OffsetDateTime;
 
 #[cfg(test)]

--- a/tests/test_ml_manifest.rs
+++ b/tests/test_ml_manifest.rs
@@ -1,6 +1,6 @@
 use atlas_c2pa_lib::asset_type::AssetType;
 use atlas_c2pa_lib::ingredient::{Ingredient, IngredientData};
-use atlas_c2pa_lib::ml::manifest::{create_model_manifest, MLManifestBuilder};
+use atlas_c2pa_lib::ml::manifest::{MLManifestBuilder, create_model_manifest};
 use atlas_c2pa_lib::ml::types::{DatasetInfo, MLFramework, ModelFormat, ModelInfo, TrainingInfo};
 
 #[test]


### PR DESCRIPTION
This PR updates the Rust edition from 2021 to 2024 in the Cargo.toml. 