### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlas-c2pa-lib" 
 edition = "2024"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Rust library for creating, signing, and verifying machine learning assets with C2PA"
 authors = ["Intel Labs"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This PR bumps the crate version from 0.1.1 to 0.1.2 following the addition of Custom Assertion Validation + tests. 