### PR TITLE
Add SHA-256 and SHA-512 Offload to Intel Xe Graphics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlas-c2pa-lib"
 edition = "2024"
-version = "0.1.2"
+version = "0.2.0"
 description = "A Rust library for creating, signing, and verifying machine learning assets with C2PA"
 authors = ["Intel Labs"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "atlas-c2pa-lib" 
+name = "atlas-c2pa-lib"
 edition = "2024"
 version = "0.1.2"
 description = "A Rust library for creating, signing, and verifying machine learning assets with C2PA"
@@ -10,6 +10,24 @@ documentation = "https://docs.rs/atlas-c2pa-lib"
 readme = "README.md"
 keywords = ["c2pa", "machine-learning", "provenance", "content-authenticity", "ml"]
 categories = ["authentication", "cryptography", "science"]
+build = "build.rs"
+
+[features]
+# Default features
+default = []
+
+# GPU-accelerated hashing using Intel Xe GPUs via SYCL/oneAPI
+# Requires Intel oneAPI to be installed for compilation
+# At runtime, requires Intel GPU drivers with Level Zero support
+#
+# Installation:
+#   apt install intel-oneapi-compiler-dpcpp-cpp
+#   source /opt/intel/oneapi/setvars.sh
+#   cargo build --features gpu-hashing
+gpu-hashing = []
+
+# Enable all GPU optimizations
+gpu-full = ["gpu-hashing"]
 
 [dependencies]
 serde = { version = "1.0.203", features = ["derive"] }
@@ -30,3 +48,16 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 mockito = "1.7.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[build-dependencies]
+
+#[[bench]]
+#name = "gpu_hash_benchmark"
+#harness = false
+#required-features = ["gpu-hashing"]
+
+[package.metadata.docs.rs]
+# Document all features on docs.rs
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ default = []
 # At runtime, requires Intel GPU drivers with Level Zero support
 #
 # Installation:
-#   apt install intel-oneapi-compiler-dpcpp-cpp
 #   source /opt/intel/oneapi/setvars.sh
 #   cargo build --features gpu-hashing
 gpu-hashing = []
@@ -52,10 +51,10 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 [build-dependencies]
 
-#[[bench]]
-#name = "gpu_hash_benchmark"
-#harness = false
-#required-features = ["gpu-hashing"]
+[[bench]]
+name = "gpu_hash_benchmark"
+harness = false
+required-features = ["gpu-hashing"]
 
 [package.metadata.docs.rs]
 # Document all features on docs.rs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - **Secure Provenance**: Cryptographic verification of asset origin and lineage
 - **Transparent Lineage**: Track datasets and components used to create models
 - **Governance Controls**: DoNotTrain assertions to control asset usage permissions
+- **GPU-Accelerated Hashing for Intel Xe GPUs**: hash algorithms optimized for Intel GPUs, and CPUs
 
 ## 📦 Installation
 
@@ -22,7 +23,7 @@ Add Atlas C2PA Library to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-atlas-c2pa-lib = "0.1.2"
+atlas-c2pa-lib = "0.2.0"
 ```
 
 ## 🚀 Quick Start
@@ -97,6 +98,9 @@ let manifest = MLManifestBuilder::new(
 .build()
 .unwrap();
 ```
+## 🔲 GPU-Accelerated Hashing for Intel Xe GPUs
+
+For GPU documentation, please visit [gpu/README.md](src/gpu/README.md).
 
 ## 📋 Use Cases
 

--- a/benches/gpu_hash_benchmark.rs
+++ b/benches/gpu_hash_benchmark.rs
@@ -1,0 +1,302 @@
+//! GPU vs CPU hashing benchmarks using Criterion
+
+use atlas_c2pa_lib::gpu::{GpuHashAlgorithm, GpuHasher};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ring::digest::{Context, SHA256, SHA384, SHA512};
+
+fn cpu_hash_sha256(data: &[u8]) -> Vec<u8> {
+    let mut ctx = Context::new(&SHA256);
+    ctx.update(data);
+    ctx.finish().as_ref().to_vec()
+}
+
+fn cpu_hash_batch_sha256(messages: &[Vec<u8>]) -> Vec<Vec<u8>> {
+    messages.iter().map(|m| cpu_hash_sha256(m)).collect()
+}
+
+fn bench_single_cpu_vs_gpu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("single_cpu_vs_gpu");
+
+    let sizes = [64, 1024, 4096, 65536, 1024 * 1024];
+
+    for size in sizes {
+        let data = vec![0xABu8; size];
+        let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256).unwrap();
+
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("cpu_ring", size), &data, |b, data| {
+            b.iter(|| cpu_hash_sha256(data))
+        });
+
+        group.bench_with_input(BenchmarkId::new("gpu", size), &data, |b, data| {
+            b.iter(|| hasher.hash(data).unwrap())
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_batch_cpu_vs_gpu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batch_cpu_vs_gpu");
+
+    let message_size = 4096;
+    let batch_sizes = [10, 100, 1000, 5000];
+
+    for batch_size in batch_sizes {
+        let messages: Vec<Vec<u8>> = (0..batch_size)
+            .map(|i| {
+                let mut msg = vec![0u8; message_size];
+                for (j, byte) in msg.iter_mut().enumerate() {
+                    *byte = ((i + j) % 256) as u8;
+                }
+                msg
+            })
+            .collect();
+
+        let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256).unwrap();
+        let total_bytes = message_size * batch_size;
+        let label = format!("{}x{}B", batch_size, message_size);
+
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("cpu_ring", &label),
+            &messages,
+            |b, messages| b.iter(|| cpu_hash_batch_sha256(messages)),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("gpu_batch", &label),
+            &messages,
+            |b, messages| b.iter(|| hasher.hash_batch(messages).unwrap()),
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_large_file_cpu_vs_gpu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("large_file_cpu_vs_gpu");
+    group.sample_size(10);
+
+    let chunk_size = 4096;
+    let num_chunks = 25600; // ~100MB
+
+    let chunks: Vec<Vec<u8>> = (0..num_chunks)
+        .map(|i| {
+            let mut chunk = vec![0u8; chunk_size];
+            for (j, byte) in chunk.iter_mut().enumerate() {
+                *byte = ((i + j) % 256) as u8;
+            }
+            chunk
+        })
+        .collect();
+
+    let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256).unwrap();
+    let total_bytes = chunk_size * num_chunks;
+
+    group.throughput(Throughput::Bytes(total_bytes as u64));
+
+    group.bench_function("cpu_ring_100MB", |b| {
+        b.iter(|| cpu_hash_batch_sha256(&chunks))
+    });
+
+    group.bench_function("gpu_batch_100MB", |b| {
+        b.iter(|| hasher.hash_batch(&chunks).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_algorithms_cpu_vs_gpu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("algorithms_cpu_vs_gpu");
+
+    let batch_size = 1000;
+    let message_size = 4096;
+
+    let messages: Vec<Vec<u8>> = (0..batch_size)
+        .map(|_| vec![0xABu8; message_size])
+        .collect();
+
+    let total_bytes = message_size * batch_size;
+    group.throughput(Throughput::Bytes(total_bytes as u64));
+
+    group.bench_function("cpu_sha256", |b| {
+        b.iter(|| cpu_hash_batch_sha256(&messages))
+    });
+
+    let hasher256 = GpuHasher::new(GpuHashAlgorithm::Sha256).unwrap();
+    group.bench_function("gpu_sha256", |b| {
+        b.iter(|| hasher256.hash_batch(&messages).unwrap())
+    });
+
+    group.bench_function("cpu_sha384", |b| {
+        b.iter(|| {
+            messages
+                .iter()
+                .map(|m| {
+                    let mut ctx = Context::new(&SHA384);
+                    ctx.update(m);
+                    ctx.finish().as_ref().to_vec()
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+
+    let hasher384 = GpuHasher::new(GpuHashAlgorithm::Sha384).unwrap();
+    group.bench_function("gpu_sha384", |b| {
+        b.iter(|| hasher384.hash_batch(&messages).unwrap())
+    });
+
+    group.bench_function("cpu_sha512", |b| {
+        b.iter(|| {
+            messages
+                .iter()
+                .map(|m| {
+                    let mut ctx = Context::new(&SHA512);
+                    ctx.update(m);
+                    ctx.finish().as_ref().to_vec()
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+
+    let hasher512 = GpuHasher::new(GpuHashAlgorithm::Sha512).unwrap();
+    group.bench_function("gpu_sha512", |b| {
+        b.iter(|| hasher512.hash_batch(&messages).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_crossover_point(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crossover_point");
+
+    let message_size = 4096;
+    let batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512];
+
+    for batch_size in batch_sizes {
+        let messages: Vec<Vec<u8>> = (0..batch_size)
+            .map(|i| {
+                let mut msg = vec![0u8; message_size];
+                for (j, byte) in msg.iter_mut().enumerate() {
+                    *byte = ((i + j) % 256) as u8;
+                }
+                msg
+            })
+            .collect();
+
+        let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256).unwrap();
+        let total_bytes = message_size * batch_size;
+
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("cpu", batch_size),
+            &messages,
+            |b, messages| b.iter(|| cpu_hash_batch_sha256(messages)),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("gpu", batch_size),
+            &messages,
+            |b, messages| b.iter(|| hasher.hash_batch(messages).unwrap()),
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_4gb_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("4gb_file");
+    group.sample_size(10);
+
+    // 4GB as 1MB chunks (4096 chunks)
+    let chunk_size = 1024 * 1024; // 1MB
+    let num_chunks = 4096; // 4GB total
+
+    eprintln!("Allocating 4GB test data ({} x 1MB chunks)...", num_chunks);
+
+    let chunks: Vec<Vec<u8>> = (0..num_chunks)
+        .map(|i| {
+            let mut chunk = vec![0u8; chunk_size];
+            for (j, byte) in chunk.iter_mut().enumerate() {
+                *byte = ((i + j) % 256) as u8;
+            }
+            chunk
+        })
+        .collect();
+
+    let total_bytes = (chunk_size * num_chunks) as u64; // 4GB
+    group.throughput(Throughput::Bytes(total_bytes));
+
+    eprintln!("Starting 4GB benchmark...");
+
+    // SHA-256
+    group.bench_function("cpu_sha256_4GB", |b| {
+        b.iter(|| cpu_hash_batch_sha256(&chunks))
+    });
+
+    let hasher256 = GpuHasher::new(GpuHashAlgorithm::Sha256).unwrap();
+    group.bench_function("gpu_sha256_4GB", |b| {
+        b.iter(|| hasher256.hash_batch(&chunks).unwrap())
+    });
+
+    // SHA-384
+    group.bench_function("cpu_sha384_4GB", |b| {
+        b.iter(|| {
+            chunks
+                .iter()
+                .map(|m| {
+                    let mut ctx = Context::new(&SHA384);
+                    ctx.update(m);
+                    ctx.finish().as_ref().to_vec()
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+
+    let hasher384 = GpuHasher::new(GpuHashAlgorithm::Sha384).unwrap();
+    group.bench_function("gpu_sha384_4GB", |b| {
+        b.iter(|| hasher384.hash_batch(&chunks).unwrap())
+    });
+
+    // SHA-512
+    group.bench_function("cpu_sha512_4GB", |b| {
+        b.iter(|| {
+            chunks
+                .iter()
+                .map(|m| {
+                    let mut ctx = Context::new(&SHA512);
+                    ctx.update(m);
+                    ctx.finish().as_ref().to_vec()
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+
+    let hasher512 = GpuHasher::new(GpuHashAlgorithm::Sha512).unwrap();
+    group.bench_function("gpu_sha512_4GB", |b| {
+        b.iter(|| hasher512.hash_batch(&chunks).unwrap())
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_single_cpu_vs_gpu,
+    bench_batch_cpu_vs_gpu,
+    bench_large_file_cpu_vs_gpu,
+    bench_algorithms_cpu_vs_gpu,
+    bench_crossover_point,
+);
+
+criterion_group!(
+    name = large_benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_4gb_file
+);
+
+criterion_main!(benches, large_benches);

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,20 @@
 //! Build script for atlas-c2pa-lib
-//!
-//! This script handles compilation of the SYCL GPU hashing library when
-//! the `gpu-hashing` feature is enabled.
 
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
-    // Only compile SYCL code if the gpu-hashing feature is enabled
-    #[cfg(feature = "gpu-hashing")]
-    compile_sycl();
-
-    // Tell cargo to rerun if these files change
     println!("cargo:rerun-if-changed=src/gpu/sycl/gpu_hash.h");
     println!("cargo:rerun-if-changed=src/gpu/sycl/gpu_hash.cpp");
     println!("cargo:rerun-if-changed=build.rs");
+
+    // IMPORTANT: build script *does* see crate features
+    #[cfg(feature = "gpu-hashing")]
+    compile_sycl();
+
+    // Without gpu-hashing, we build nothing and the pure-CPU
+    // code in Rust should handle things.
 }
 
 #[cfg(feature = "gpu-hashing")]
@@ -25,179 +24,112 @@ fn compile_sycl() {
 
     let sycl_src = manifest_dir.join("src/gpu/sycl");
     let cpp_file = sycl_src.join("gpu_hash.cpp");
-    let lib_file = out_dir.join("libgpu_hash.a");
-    let obj_file = out_dir.join("gpu_hash.o");
+    let lib_file = out_dir.join("libgpu_hash.so");
 
-    // Find the SYCL compiler (icpx from Intel oneAPI)
     let compiler = find_sycl_compiler();
-
     println!("cargo:warning=Using SYCL compiler: {}", compiler);
 
-    // Compile the SYCL code to object file
-    let compile_status = Command::new(&compiler)
+    // One step: compile + link as shared library with device image
+    let output = Command::new(&compiler)
         .args(&[
             "-fsycl",
-            "-c",
             "-fPIC",
             "-O3",
             "-std=c++17",
+            "-fno-builtin",
+            "-shared",
             "-I",
             sycl_src.to_str().unwrap(),
-            "-o",
-            obj_file.to_str().unwrap(),
             cpp_file.to_str().unwrap(),
+            "-o",
+            lib_file.to_str().unwrap(),
         ])
-        .status();
+        .output();
 
-    match compile_status {
-        Ok(status) if status.success() => {
-            println!("cargo:warning=SYCL compilation successful");
+    match output {
+        Ok(out) if out.status.success() => {
+            println!("cargo:warning=SYCL shared library built successfully");
         }
-        Ok(status) => {
-            // Compilation failed, try to provide helpful error message
-            eprintln!("SYCL compilation failed with status: {}", status);
-            eprintln!("Make sure Intel oneAPI is installed and sourced:");
-            eprintln!("  source /opt/intel/oneapi/setvars.sh");
-
-            // Fall back to stub implementation
+        Ok(out) => {
+            println!("cargo:warning=SYCL compilation/link failed:");
+            println!(
+                "cargo:warning=stderr: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
             create_stub_library(&out_dir);
             return;
         }
         Err(e) => {
-            eprintln!("Failed to run SYCL compiler '{}': {}", compiler, e);
-            eprintln!("Make sure Intel oneAPI is installed.");
-            eprintln!("On Ubuntu: apt install intel-oneapi-compiler-dpcpp-cpp");
-            eprintln!("Then source the environment: source /opt/intel/oneapi/setvars.sh");
-
-            // Fall back to stub implementation
+            println!("cargo:warning=Failed to run SYCL compiler: {}", e);
             create_stub_library(&out_dir);
             return;
         }
     }
 
-    // Create static library from object file
-    let ar_status = Command::new("ar")
-        .args(&[
-            "rcs",
-            lib_file.to_str().unwrap(),
-            obj_file.to_str().unwrap(),
-        ])
-        .status()
-        .expect("Failed to run ar");
-
-    if !ar_status.success() {
-        panic!("Failed to create static library");
-    }
-
-    // Tell cargo where to find the library
+    // Tell Rust to link against the shared lib
     println!("cargo:rustc-link-search=native={}", out_dir.display());
-    println!("cargo:rustc-link-lib=static=gpu_hash");
+    println!("cargo:rustc-link-lib=dylib=gpu_hash");
 
-    // Link SYCL runtime
+    // These are usually resolved transitively, but leaving them explicit is fine
     println!("cargo:rustc-link-lib=sycl");
     println!("cargo:rustc-link-lib=stdc++");
-
-    // Link Level Zero if available (for Intel GPUs)
-    if has_level_zero() {
-        println!("cargo:rustc-link-lib=ze_loader");
-    }
 }
 
 #[cfg(feature = "gpu-hashing")]
 fn find_sycl_compiler() -> String {
-    // Check for icpx (Intel oneAPI DPC++ compiler)
-    if which_exists("icpx") {
+    if Command::new("icpx")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
         return "icpx".to_string();
     }
-
-    // Check for dpcpp (older name)
-    if which_exists("dpcpp") {
-        return "dpcpp".to_string();
-    }
-
-    // Check common installation paths
-    let common_paths = [
-        "/opt/intel/oneapi/compiler/latest/bin/icpx",
-        "/opt/intel/oneapi/compiler/latest/linux/bin/icpx",
-    ];
-
-    for path in &common_paths {
+    for path in &["/opt/intel/oneapi/compiler/latest/bin/icpx"] {
         if std::path::Path::new(path).exists() {
             return path.to_string();
         }
     }
-
-    // Default to icpx, will fail later with helpful message
     "icpx".to_string()
 }
 
 #[cfg(feature = "gpu-hashing")]
-fn which_exists(cmd: &str) -> bool {
-    Command::new("which")
-        .arg(cmd)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-#[cfg(feature = "gpu-hashing")]
-fn has_level_zero() -> bool {
-    // Check if Level Zero is available
-    Command::new("pkg-config")
-        .args(&["--exists", "level-zero"])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-#[cfg(feature = "gpu-hashing")]
 fn create_stub_library(out_dir: &PathBuf) {
-    // Create a stub C library that returns "not available"
+    println!("cargo:warning=Creating stub library (no SYCL)");
+
     let stub_code = r#"
 #include <stdint.h>
 #include <stddef.h>
-
 typedef enum { GPU_HASH_SHA256 = 0, GPU_HASH_SHA384 = 1, GPU_HASH_SHA512 = 2 } GpuHashAlgorithm;
-typedef enum { 
-    GPU_HASH_SUCCESS = 0, GPU_HASH_ERROR_NO_DEVICE = 1, GPU_HASH_ERROR_INVALID_ALGORITHM = 2,
+typedef enum { GPU_HASH_SUCCESS = 0, GPU_HASH_ERROR_NO_DEVICE = 1, GPU_HASH_ERROR_INVALID_ALGORITHM = 2,
     GPU_HASH_ERROR_MEMORY_ALLOCATION = 3, GPU_HASH_ERROR_KERNEL_EXECUTION = 4,
-    GPU_HASH_ERROR_INVALID_INPUT = 5, GPU_HASH_ERROR_NOT_INITIALIZED = 6, GPU_HASH_ERROR_UNKNOWN = 99
-} GpuHashError;
+    GPU_HASH_ERROR_INVALID_INPUT = 5, GPU_HASH_ERROR_NOT_INITIALIZED = 6, GPU_HASH_ERROR_UNKNOWN = 99 } GpuHashError;
 typedef enum { GPU_DEVICE_TYPE_GPU = 0, GPU_DEVICE_TYPE_CPU = 1, GPU_DEVICE_TYPE_ACCELERATOR = 2 } GpuDeviceType;
-
-typedef struct {
-    char name[256]; char vendor[256]; char driver_version[64];
-    GpuDeviceType device_type; uint32_t max_compute_units;
-    uint64_t global_memory_size; uint64_t local_memory_size;
-    size_t max_work_group_size; int is_intel; int is_intel_xe;
-} GpuDeviceInfo;
-
+typedef struct { char name[256]; char vendor[256]; char driver_version[64]; GpuDeviceType device_type;
+    uint32_t max_compute_units; uint64_t global_memory_size; uint64_t local_memory_size;
+    size_t max_work_group_size; int is_intel; int is_intel_xe; } GpuDeviceInfo;
 typedef void* GpuHashContextHandle;
-
-static const char* last_error = "SYCL not available - Intel oneAPI not installed";
-
+static const char* last_error = "SYCL not available";
 GpuHashError gpu_hash_init(void) { return GPU_HASH_SUCCESS; }
 void gpu_hash_cleanup(void) {}
 int gpu_hash_is_available(void) { return 0; }
 int gpu_hash_get_device_count(void) { return 0; }
-GpuHashError gpu_hash_get_device_info(int idx, GpuDeviceInfo* info) { return GPU_HASH_ERROR_NO_DEVICE; }
-GpuHashError gpu_hash_create_context(GpuHashAlgorithm alg, int idx, GpuHashContextHandle* h) { return GPU_HASH_ERROR_NO_DEVICE; }
-void gpu_hash_destroy_context(GpuHashContextHandle h) {}
-GpuHashError gpu_hash_single(GpuHashContextHandle h, const uint8_t* in, size_t len, uint8_t* out, size_t* olen) { return GPU_HASH_ERROR_NO_DEVICE; }
-GpuHashError gpu_hash_batch(GpuHashContextHandle h, const uint8_t** ins, const size_t* lens, size_t n, uint8_t** outs, size_t osize) { return GPU_HASH_ERROR_NO_DEVICE; }
-GpuHashError gpu_hash_batch_fixed(GpuHashContextHandle h, const uint8_t* in, size_t msize, size_t n, uint8_t* out) { return GPU_HASH_ERROR_NO_DEVICE; }
+GpuHashError gpu_hash_get_device_info(int idx, GpuDeviceInfo* info) { (void)idx; (void)info; return GPU_HASH_ERROR_NO_DEVICE; }
+GpuHashError gpu_hash_create_context(GpuHashAlgorithm alg, int idx, GpuHashContextHandle* h) { (void)alg; (void)idx; (void)h; return GPU_HASH_ERROR_NO_DEVICE; }
+void gpu_hash_destroy_context(GpuHashContextHandle h) { (void)h; }
+GpuHashError gpu_hash_single(GpuHashContextHandle h, const uint8_t* in, size_t len, uint8_t* out, size_t* olen) { (void)h; (void)in; (void)len; (void)out; (void)olen; return GPU_HASH_ERROR_NO_DEVICE; }
+GpuHashError gpu_hash_batch(GpuHashContextHandle h, const uint8_t** ins, const size_t* lens, size_t n, uint8_t** outs, size_t osize) { (void)h; (void)ins; (void)lens; (void)n; (void)outs; (void)osize; return GPU_HASH_ERROR_NO_DEVICE; }
+GpuHashError gpu_hash_batch_fixed(GpuHashContextHandle h, const uint8_t* in, size_t msize, size_t n, uint8_t* out) { (void)h; (void)in; (void)msize; (void)n; (void)out; return GPU_HASH_ERROR_NO_DEVICE; }
 size_t gpu_hash_output_size(GpuHashAlgorithm alg) { return alg == GPU_HASH_SHA256 ? 32 : alg == GPU_HASH_SHA384 ? 48 : 64; }
 const char* gpu_hash_get_last_error(void) { return last_error; }
 "#;
 
     let stub_c = out_dir.join("gpu_hash_stub.c");
     std::fs::write(&stub_c, stub_code).expect("Failed to write stub");
-
     let obj_file = out_dir.join("gpu_hash_stub.o");
-    let lib_file = out_dir.join("libgpu_hash.a");
+    let lib_file = out_dir.join("libgpu_hash.so");
 
-    // Compile stub
-    let status = Command::new("cc")
+    Command::new("cc")
         .args(&[
             "-c",
             "-fPIC",
@@ -206,23 +138,18 @@ const char* gpu_hash_get_last_error(void) { return last_error; }
             stub_c.to_str().unwrap(),
         ])
         .status()
-        .expect("Failed to compile stub");
+        .expect("cc failed");
 
-    if !status.success() {
-        panic!("Failed to compile stub library");
-    }
-
-    // Create library
-    Command::new("ar")
+    Command::new("cc")
         .args(&[
-            "rcs",
+            "-shared",
+            "-o",
             lib_file.to_str().unwrap(),
             obj_file.to_str().unwrap(),
         ])
         .status()
-        .expect("Failed to create stub library");
+        .expect("cc failed");
 
-    println!("cargo:warning=Created stub GPU library (SYCL not available)");
     println!("cargo:rustc-link-search=native={}", out_dir.display());
-    println!("cargo:rustc-link-lib=static=gpu_hash");
+    println!("cargo:rustc-link-lib=dylib=gpu_hash");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,228 @@
+//! Build script for atlas-c2pa-lib
+//!
+//! This script handles compilation of the SYCL GPU hashing library when
+//! the `gpu-hashing` feature is enabled.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    // Only compile SYCL code if the gpu-hashing feature is enabled
+    #[cfg(feature = "gpu-hashing")]
+    compile_sycl();
+
+    // Tell cargo to rerun if these files change
+    println!("cargo:rerun-if-changed=src/gpu/sycl/gpu_hash.h");
+    println!("cargo:rerun-if-changed=src/gpu/sycl/gpu_hash.cpp");
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+#[cfg(feature = "gpu-hashing")]
+fn compile_sycl() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    let sycl_src = manifest_dir.join("src/gpu/sycl");
+    let cpp_file = sycl_src.join("gpu_hash.cpp");
+    let lib_file = out_dir.join("libgpu_hash.a");
+    let obj_file = out_dir.join("gpu_hash.o");
+
+    // Find the SYCL compiler (icpx from Intel oneAPI)
+    let compiler = find_sycl_compiler();
+
+    println!("cargo:warning=Using SYCL compiler: {}", compiler);
+
+    // Compile the SYCL code to object file
+    let compile_status = Command::new(&compiler)
+        .args(&[
+            "-fsycl",
+            "-c",
+            "-fPIC",
+            "-O3",
+            "-std=c++17",
+            "-I",
+            sycl_src.to_str().unwrap(),
+            "-o",
+            obj_file.to_str().unwrap(),
+            cpp_file.to_str().unwrap(),
+        ])
+        .status();
+
+    match compile_status {
+        Ok(status) if status.success() => {
+            println!("cargo:warning=SYCL compilation successful");
+        }
+        Ok(status) => {
+            // Compilation failed, try to provide helpful error message
+            eprintln!("SYCL compilation failed with status: {}", status);
+            eprintln!("Make sure Intel oneAPI is installed and sourced:");
+            eprintln!("  source /opt/intel/oneapi/setvars.sh");
+
+            // Fall back to stub implementation
+            create_stub_library(&out_dir);
+            return;
+        }
+        Err(e) => {
+            eprintln!("Failed to run SYCL compiler '{}': {}", compiler, e);
+            eprintln!("Make sure Intel oneAPI is installed.");
+            eprintln!("On Ubuntu: apt install intel-oneapi-compiler-dpcpp-cpp");
+            eprintln!("Then source the environment: source /opt/intel/oneapi/setvars.sh");
+
+            // Fall back to stub implementation
+            create_stub_library(&out_dir);
+            return;
+        }
+    }
+
+    // Create static library from object file
+    let ar_status = Command::new("ar")
+        .args(&[
+            "rcs",
+            lib_file.to_str().unwrap(),
+            obj_file.to_str().unwrap(),
+        ])
+        .status()
+        .expect("Failed to run ar");
+
+    if !ar_status.success() {
+        panic!("Failed to create static library");
+    }
+
+    // Tell cargo where to find the library
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=gpu_hash");
+
+    // Link SYCL runtime
+    println!("cargo:rustc-link-lib=sycl");
+    println!("cargo:rustc-link-lib=stdc++");
+
+    // Link Level Zero if available (for Intel GPUs)
+    if has_level_zero() {
+        println!("cargo:rustc-link-lib=ze_loader");
+    }
+}
+
+#[cfg(feature = "gpu-hashing")]
+fn find_sycl_compiler() -> String {
+    // Check for icpx (Intel oneAPI DPC++ compiler)
+    if which_exists("icpx") {
+        return "icpx".to_string();
+    }
+
+    // Check for dpcpp (older name)
+    if which_exists("dpcpp") {
+        return "dpcpp".to_string();
+    }
+
+    // Check common installation paths
+    let common_paths = [
+        "/opt/intel/oneapi/compiler/latest/bin/icpx",
+        "/opt/intel/oneapi/compiler/latest/linux/bin/icpx",
+    ];
+
+    for path in &common_paths {
+        if std::path::Path::new(path).exists() {
+            return path.to_string();
+        }
+    }
+
+    // Default to icpx, will fail later with helpful message
+    "icpx".to_string()
+}
+
+#[cfg(feature = "gpu-hashing")]
+fn which_exists(cmd: &str) -> bool {
+    Command::new("which")
+        .arg(cmd)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(feature = "gpu-hashing")]
+fn has_level_zero() -> bool {
+    // Check if Level Zero is available
+    Command::new("pkg-config")
+        .args(&["--exists", "level-zero"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(feature = "gpu-hashing")]
+fn create_stub_library(out_dir: &PathBuf) {
+    // Create a stub C library that returns "not available"
+    let stub_code = r#"
+#include <stdint.h>
+#include <stddef.h>
+
+typedef enum { GPU_HASH_SHA256 = 0, GPU_HASH_SHA384 = 1, GPU_HASH_SHA512 = 2 } GpuHashAlgorithm;
+typedef enum { 
+    GPU_HASH_SUCCESS = 0, GPU_HASH_ERROR_NO_DEVICE = 1, GPU_HASH_ERROR_INVALID_ALGORITHM = 2,
+    GPU_HASH_ERROR_MEMORY_ALLOCATION = 3, GPU_HASH_ERROR_KERNEL_EXECUTION = 4,
+    GPU_HASH_ERROR_INVALID_INPUT = 5, GPU_HASH_ERROR_NOT_INITIALIZED = 6, GPU_HASH_ERROR_UNKNOWN = 99
+} GpuHashError;
+typedef enum { GPU_DEVICE_TYPE_GPU = 0, GPU_DEVICE_TYPE_CPU = 1, GPU_DEVICE_TYPE_ACCELERATOR = 2 } GpuDeviceType;
+
+typedef struct {
+    char name[256]; char vendor[256]; char driver_version[64];
+    GpuDeviceType device_type; uint32_t max_compute_units;
+    uint64_t global_memory_size; uint64_t local_memory_size;
+    size_t max_work_group_size; int is_intel; int is_intel_xe;
+} GpuDeviceInfo;
+
+typedef void* GpuHashContextHandle;
+
+static const char* last_error = "SYCL not available - Intel oneAPI not installed";
+
+GpuHashError gpu_hash_init(void) { return GPU_HASH_SUCCESS; }
+void gpu_hash_cleanup(void) {}
+int gpu_hash_is_available(void) { return 0; }
+int gpu_hash_get_device_count(void) { return 0; }
+GpuHashError gpu_hash_get_device_info(int idx, GpuDeviceInfo* info) { return GPU_HASH_ERROR_NO_DEVICE; }
+GpuHashError gpu_hash_create_context(GpuHashAlgorithm alg, int idx, GpuHashContextHandle* h) { return GPU_HASH_ERROR_NO_DEVICE; }
+void gpu_hash_destroy_context(GpuHashContextHandle h) {}
+GpuHashError gpu_hash_single(GpuHashContextHandle h, const uint8_t* in, size_t len, uint8_t* out, size_t* olen) { return GPU_HASH_ERROR_NO_DEVICE; }
+GpuHashError gpu_hash_batch(GpuHashContextHandle h, const uint8_t** ins, const size_t* lens, size_t n, uint8_t** outs, size_t osize) { return GPU_HASH_ERROR_NO_DEVICE; }
+GpuHashError gpu_hash_batch_fixed(GpuHashContextHandle h, const uint8_t* in, size_t msize, size_t n, uint8_t* out) { return GPU_HASH_ERROR_NO_DEVICE; }
+size_t gpu_hash_output_size(GpuHashAlgorithm alg) { return alg == GPU_HASH_SHA256 ? 32 : alg == GPU_HASH_SHA384 ? 48 : 64; }
+const char* gpu_hash_get_last_error(void) { return last_error; }
+"#;
+
+    let stub_c = out_dir.join("gpu_hash_stub.c");
+    std::fs::write(&stub_c, stub_code).expect("Failed to write stub");
+
+    let obj_file = out_dir.join("gpu_hash_stub.o");
+    let lib_file = out_dir.join("libgpu_hash.a");
+
+    // Compile stub
+    let status = Command::new("cc")
+        .args(&[
+            "-c",
+            "-fPIC",
+            "-o",
+            obj_file.to_str().unwrap(),
+            stub_c.to_str().unwrap(),
+        ])
+        .status()
+        .expect("Failed to compile stub");
+
+    if !status.success() {
+        panic!("Failed to compile stub library");
+    }
+
+    // Create library
+    Command::new("ar")
+        .args(&[
+            "rcs",
+            lib_file.to_str().unwrap(),
+            obj_file.to_str().unwrap(),
+        ])
+        .status()
+        .expect("Failed to create stub library");
+
+    println!("cargo:warning=Created stub GPU library (SYCL not available)");
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=gpu_hash");
+}

--- a/src/gpu/README.md
+++ b/src/gpu/README.md
@@ -285,4 +285,4 @@ The GPU hashing module consists of:
 
 ## License
 
-MIT OR Apache-2.0
+Apache-2.0

--- a/src/gpu/README.md
+++ b/src/gpu/README.md
@@ -1,0 +1,288 @@
+# GPU-Accelerated Hashing for Intel Xe GPUs (SYCL/oneAPI)
+
+This module provides GPU-accelerated hashing support for Intel Xe GPUs using SYCL/oneAPI - Intel's modern GPU programming framework.
+
+## Features
+
+- **SHA-256, SHA-384, SHA-512** hash algorithms optimized for Intel GPUs
+- **Automatic fallback** to CPU when GPU is unavailable
+- **Batch processing** for efficiently hashing multiple messages in parallel
+- **File hashing** support for ML model files
+
+## Prerequisites
+
+### Hardware
+- Intel GPU with Level Zero support:
+  - Intel Arc (discrete GPUs)
+  - Intel Iris Xe Graphics
+  - Intel UHD Graphics 
+  - Other Intel Xe-based GPUs
+
+### Software
+
+#### Linux (Ubuntu/Debian)
+
+1. **Install Intel oneAPI Base Toolkit:**
+```bash
+# Add Intel repository
+wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+    sudo gpg --dearmor -o /usr/share/keyrings/intel-oneapi-archive-keyring.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] \
+    https://apt.repos.intel.com/oneapi all main" | \
+    sudo tee /etc/apt/sources.list.d/intel-oneapi.list
+
+sudo apt update
+
+# Install DPC++ compiler
+sudo apt install intel-oneapi-compiler-dpcpp-cpp
+
+# Install Level Zero loader
+sudo apt install level-zero
+```
+
+2. **Install Intel GPU drivers:**
+```bash
+# Add Intel graphics repository
+wget -qO - https://repositories.intel.com/graphics/intel-graphics.key | \
+    sudo gpg --dearmor -o /usr/share/keyrings/intel-graphics.gpg
+    
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
+    https://repositories.intel.com/graphics/ubuntu jammy main" | \
+    sudo tee /etc/apt/sources.list.d/intel-graphics.list
+
+sudo apt update
+sudo apt install intel-opencl-icd intel-level-zero-gpu level-zero
+```
+
+3. **Source oneAPI environment before building:**
+```bash
+source /opt/intel/oneapi/setvars.sh
+```
+
+#### Fedora/RHEL
+
+```bash
+# Install Intel oneAPI
+sudo dnf install intel-oneapi-compiler-dpcpp-cpp
+
+# Install Intel compute runtime  
+sudo dnf install intel-compute-runtime level-zero
+
+# Source environment
+source /opt/intel/oneapi/setvars.sh
+```
+
+## Building
+
+The library must be built with the oneAPI environment sourced:
+
+```bash
+# Source oneAPI environment
+source /opt/intel/oneapi/setvars.sh
+
+# Build with GPU support
+cargo build --features gpu-hashing
+
+# Run tests
+cargo test --features gpu-hashing
+
+# Run benchmarks
+cargo bench --features gpu-hashing
+```
+
+If oneAPI is not available, the build will create a stub library that returns "GPU not available" - the library will still compile and fall back to CPU hashing.
+
+## Usage
+
+### Basic Hashing
+
+```rust
+use atlas_c2pa_lib::gpu::{GpuHasher, GpuHashAlgorithm, hash_auto};
+
+// Automatic selection (GPU if available, CPU otherwise)
+let hash = hash_auto(b"Hello, World!", GpuHashAlgorithm::Sha256)?;
+println!("Hash: {}", hex::encode(&hash));
+```
+
+### Using the Hasher Directly
+
+```rust
+use atlas_c2pa_lib::gpu::{GpuHasher, GpuHashAlgorithm};
+
+// Create a hasher for SHA-256
+let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+
+// Hash single messages
+let hash1 = hasher.hash(b"Message 1")?;
+let hash2 = hasher.hash(b"Message 2")?;
+```
+
+### Batch Processing
+
+Batch processing is significantly faster when you have many messages to hash:
+
+```rust
+use atlas_c2pa_lib::gpu::{GpuHasher, GpuHashAlgorithm};
+
+let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+
+let messages = vec![
+    b"Model weights chunk 1".to_vec(),
+    b"Model weights chunk 2".to_vec(),
+    b"Model weights chunk 3".to_vec(),
+    // ... more chunks
+];
+
+// Hash all messages in parallel on GPU
+let hashes = hasher.hash_batch(&messages)?;
+```
+
+### Hashing ML Model Files
+
+```rust
+use atlas_c2pa_lib::gpu::{GpuHasher, GpuHashAlgorithm};
+use std::path::Path;
+
+let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+
+// Hash a single file
+let hash = hasher.hash_file(Path::new("model.onnx"))?;
+
+// Hash multiple files in parallel
+let hashes = hasher.hash_files(&[
+    Path::new("model.onnx"),
+    Path::new("weights.bin"),
+    Path::new("config.json"),
+])?;
+```
+
+### Checking GPU Availability
+
+```rust
+use atlas_c2pa_lib::gpu::{is_gpu_available, get_available_devices};
+
+if is_gpu_available() {
+    println!("GPU hashing is available!");
+    
+    // List available devices
+    for device in get_available_devices()? {
+        println!("Device: {} ({})", device.name(), device.vendor());
+        println!("  Type: {:?}", device.device_type());
+        println!("  Compute Units: {}", device.max_compute_units());
+        println!("  Is Intel Xe: {}", device.is_intel_xe());
+    }
+} else {
+    println!("GPU not available, using CPU fallback");
+}
+```
+
+## Performance
+
+GPU hashing provides the best performance for:
+
+1. **Large files** (> 4KB) - GPU initialization overhead is amortized
+2. **Batch processing** - Multiple messages processed in parallel
+3. **ML model hashing** - Large model files benefit significantly
+
+For small messages (< 4KB), the library automatically uses CPU hashing.
+
+### Benchmarks
+
+Run benchmarks to measure performance on your hardware:
+
+```bash
+source /opt/intel/oneapi/setvars.sh
+cargo bench --features gpu-hashing
+```
+
+## Supported Algorithms
+
+| Algorithm | Output Size | Block Size | C2PA Compliant |
+|-----------|-------------|------------|----------------|
+| SHA-256   | 32 bytes    | 64 bytes   | ✓              |
+| SHA-384   | 48 bytes    | 128 bytes  | ✓              |
+| SHA-512   | 64 bytes    | 128 bytes  | ✓              |
+
+## Troubleshooting
+
+### GPU Not Detected
+
+1. Verify Intel GPU is present:
+   ```bash
+   lspci | grep -i "vga\|3d\|display"
+   ```
+
+2. Check Level Zero is available:
+   ```bash
+   # List Level Zero devices
+   ls /dev/dri/
+   
+   # Check Level Zero loader
+   ldconfig -p | grep ze_loader
+   ```
+
+3. Verify oneAPI environment is sourced:
+   ```bash
+   which icpx
+   echo $SYCL_DEVICE_FILTER
+   ```
+
+4. List SYCL devices:
+   ```bash
+   sycl-ls
+   ```
+
+### Compilation Errors
+
+If you see "SYCL compiler not found":
+
+1. Install Intel oneAPI:
+   ```bash
+   sudo apt install intel-oneapi-compiler-dpcpp-cpp
+   ```
+
+2. Source the environment:
+   ```bash
+   source /opt/intel/oneapi/setvars.sh
+   ```
+
+3. Verify compiler is available:
+   ```bash
+   which icpx
+   icpx --version
+   ```
+
+### Performance Issues
+
+1. Ensure release builds:
+   ```bash
+   cargo build --release --features gpu-hashing
+   ```
+
+2. For batch processing, use batch sizes > 4 messages
+
+3. For large files, ensure data fits in GPU memory
+
+## Architecture
+
+The GPU hashing module consists of:
+
+1. **SYCL Kernels** (`src/gpu/sycl/`):
+   - `gpu_hash.cpp` - SHA-256/384/512 SYCL implementation
+   - `gpu_hash.h` - C API header
+
+2. **Rust FFI** (`src/gpu/`):
+   - `mod.rs` - Public API
+   - `ffi.rs` - C bindings
+   - `hasher.rs` - Hash computation
+   - `context.rs` - Device management
+   - `error.rs` - Error types
+
+3. **Build System** (`build.rs`):
+   - Compiles SYCL code using icpx
+   - Creates stub library if oneAPI not available
+
+## License
+
+MIT OR Apache-2.0

--- a/src/gpu/context.rs
+++ b/src/gpu/context.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides device discovery and information for Intel Xe GPUs.
 
-use super::error::{GpuError, GpuResult, check_error};
+use super::error::{GpuResult, check_error};
 use super::ffi;
 
 /// Type of GPU device
@@ -142,28 +142,6 @@ pub fn get_available_devices() -> GpuResult<Vec<GpuDevice>> {
     }
 
     Ok(devices)
-}
-
-/// Get the best available Intel Xe GPU device
-pub fn get_best_intel_device() -> GpuResult<GpuDevice> {
-    let devices = get_available_devices()?;
-
-    // First try to find an Intel Xe GPU
-    if let Some(device) = devices.iter().find(|d| d.is_intel_xe) {
-        return Ok(device.clone());
-    }
-
-    // Fall back to any Intel device
-    if let Some(device) = devices.iter().find(|d| d.is_intel) {
-        return Ok(device.clone());
-    }
-
-    // Fall back to any GPU
-    if let Some(device) = devices.into_iter().next() {
-        return Ok(device);
-    }
-
-    Err(GpuError::NoDeviceFound)
 }
 
 #[cfg(test)]

--- a/src/gpu/context.rs
+++ b/src/gpu/context.rs
@@ -1,0 +1,192 @@
+//! GPU Device Management
+//!
+//! This module provides device discovery and information for Intel Xe GPUs.
+
+use super::error::{GpuError, GpuResult, check_error};
+use super::ffi;
+
+/// Type of GPU device
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuDeviceType {
+    /// GPU device
+    Gpu,
+    /// CPU device (can run SYCL code)
+    Cpu,
+    /// Accelerator device
+    Accelerator,
+}
+
+impl From<ffi::GpuDeviceType> for GpuDeviceType {
+    fn from(dt: ffi::GpuDeviceType) -> Self {
+        match dt {
+            ffi::GpuDeviceType::Gpu => GpuDeviceType::Gpu,
+            ffi::GpuDeviceType::Cpu => GpuDeviceType::Cpu,
+            ffi::GpuDeviceType::Accelerator => GpuDeviceType::Accelerator,
+        }
+    }
+}
+
+/// Information about a GPU device
+#[derive(Debug, Clone)]
+pub struct GpuDevice {
+    /// Device name
+    name: String,
+    /// Vendor name
+    vendor: String,
+    /// Driver version
+    driver_version: String,
+    /// Device type
+    device_type: GpuDeviceType,
+    /// Maximum compute units
+    max_compute_units: u32,
+    /// Global memory size in bytes
+    global_memory_size: u64,
+    /// Local memory size in bytes
+    local_memory_size: u64,
+    /// Maximum work group size
+    max_work_group_size: usize,
+    /// Whether this is an Intel device
+    is_intel: bool,
+    /// Whether this is an Intel Xe GPU
+    is_intel_xe: bool,
+    /// Device index for selection
+    device_index: i32,
+}
+
+impl GpuDevice {
+    /// Get the device name
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the vendor name
+    pub fn vendor(&self) -> &str {
+        &self.vendor
+    }
+
+    /// Get the driver version
+    pub fn driver_version(&self) -> &str {
+        &self.driver_version
+    }
+
+    /// Get the device type
+    pub fn device_type(&self) -> GpuDeviceType {
+        self.device_type
+    }
+
+    /// Get the maximum compute units
+    pub fn max_compute_units(&self) -> u32 {
+        self.max_compute_units
+    }
+
+    /// Get the maximum work group size
+    pub fn max_work_group_size(&self) -> usize {
+        self.max_work_group_size
+    }
+
+    /// Get global memory size in bytes
+    pub fn global_memory_size(&self) -> u64 {
+        self.global_memory_size
+    }
+
+    /// Get local memory size in bytes
+    pub fn local_memory_size(&self) -> u64 {
+        self.local_memory_size
+    }
+
+    /// Check if this is an Intel device
+    pub fn is_intel(&self) -> bool {
+        self.is_intel
+    }
+
+    /// Check if this is an Intel Xe GPU
+    pub fn is_intel_xe(&self) -> bool {
+        self.is_intel_xe
+    }
+
+    /// Get the device index (for internal use)
+    pub(crate) fn device_index(&self) -> i32 {
+        self.device_index
+    }
+}
+
+/// Get all available GPU devices
+pub fn get_available_devices() -> GpuResult<Vec<GpuDevice>> {
+    // Initialize the library
+    unsafe {
+        let err = ffi::gpu_hash_init();
+        check_error(err)?;
+    }
+
+    let count = unsafe { ffi::gpu_hash_get_device_count() };
+    let mut devices = Vec::with_capacity(count as usize);
+
+    for i in 0..count {
+        let mut info = ffi::GpuDeviceInfo::default();
+        let err = unsafe { ffi::gpu_hash_get_device_info(i, &mut info) };
+        check_error(err)?;
+
+        devices.push(GpuDevice {
+            name: ffi::device_info_name(&info),
+            vendor: ffi::device_info_vendor(&info),
+            driver_version: ffi::device_info_driver_version(&info),
+            device_type: info.device_type.into(),
+            max_compute_units: info.max_compute_units,
+            global_memory_size: info.global_memory_size,
+            local_memory_size: info.local_memory_size,
+            max_work_group_size: info.max_work_group_size,
+            is_intel: info.is_intel != 0,
+            is_intel_xe: info.is_intel_xe != 0,
+            device_index: i,
+        });
+    }
+
+    Ok(devices)
+}
+
+/// Get the best available Intel Xe GPU device
+pub fn get_best_intel_device() -> GpuResult<GpuDevice> {
+    let devices = get_available_devices()?;
+
+    // First try to find an Intel Xe GPU
+    if let Some(device) = devices.iter().find(|d| d.is_intel_xe) {
+        return Ok(device.clone());
+    }
+
+    // Fall back to any Intel device
+    if let Some(device) = devices.iter().find(|d| d.is_intel) {
+        return Ok(device.clone());
+    }
+
+    // Fall back to any GPU
+    if let Some(device) = devices.into_iter().next() {
+        return Ok(device);
+    }
+
+    Err(GpuError::NoDeviceFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_device_discovery() {
+        match get_available_devices() {
+            Ok(devices) => {
+                println!("Found {} devices", devices.len());
+                for device in &devices {
+                    println!(
+                        "  {} ({}) - Intel Xe: {}",
+                        device.name(),
+                        device.vendor(),
+                        device.is_intel_xe()
+                    );
+                }
+            }
+            Err(e) => {
+                println!("Device discovery failed (expected if no GPU): {}", e);
+            }
+        }
+    }
+}

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -1,0 +1,104 @@
+//! GPU Error Types
+//!
+//! This module defines error types for GPU hashing operations.
+
+use super::ffi;
+use std::fmt;
+
+/// Result type for GPU operations
+pub type GpuResult<T> = Result<T, GpuError>;
+
+/// Errors that can occur during GPU hashing operations
+#[derive(Debug)]
+pub enum GpuError {
+    /// No compatible GPU device was found
+    NoDeviceFound,
+
+    /// Invalid hash algorithm specified
+    InvalidAlgorithm,
+
+    /// GPU memory allocation failed
+    MemoryAllocationFailed(String),
+
+    /// Kernel execution failed
+    KernelExecutionFailed(String),
+
+    /// Invalid input data
+    InvalidInput(String),
+
+    /// Library not initialized
+    NotInitialized,
+
+    /// Generic error with message
+    Other(String),
+}
+
+impl fmt::Display for GpuError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GpuError::NoDeviceFound => {
+                write!(
+                    f,
+                    "No compatible Intel GPU device found. Ensure Intel GPU drivers and oneAPI runtime are installed."
+                )
+            }
+            GpuError::InvalidAlgorithm => {
+                write!(f, "Invalid hash algorithm specified")
+            }
+            GpuError::MemoryAllocationFailed(msg) => {
+                write!(f, "GPU memory allocation failed: {msg}")
+            }
+            GpuError::KernelExecutionFailed(msg) => {
+                write!(f, "Kernel execution failed: {msg}")
+            }
+            GpuError::InvalidInput(msg) => {
+                write!(f, "Invalid input: {msg}")
+            }
+            GpuError::NotInitialized => {
+                write!(f, "GPU hashing library not initialized")
+            }
+            GpuError::Other(msg) => {
+                write!(f, "GPU error: {msg}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GpuError {}
+
+impl From<String> for GpuError {
+    fn from(s: String) -> Self {
+        GpuError::Other(s)
+    }
+}
+
+impl From<&str> for GpuError {
+    fn from(s: &str) -> Self {
+        GpuError::Other(s.to_string())
+    }
+}
+
+impl From<ffi::GpuHashError> for GpuError {
+    fn from(err: ffi::GpuHashError) -> Self {
+        let msg = ffi::get_last_error_message();
+        match err {
+            ffi::GpuHashError::Success => GpuError::Other("Unexpected success error".to_string()),
+            ffi::GpuHashError::NoDevice => GpuError::NoDeviceFound,
+            ffi::GpuHashError::InvalidAlgorithm => GpuError::InvalidAlgorithm,
+            ffi::GpuHashError::MemoryAllocation => GpuError::MemoryAllocationFailed(msg),
+            ffi::GpuHashError::KernelExecution => GpuError::KernelExecutionFailed(msg),
+            ffi::GpuHashError::InvalidInput => GpuError::InvalidInput(msg),
+            ffi::GpuHashError::NotInitialized => GpuError::NotInitialized,
+            ffi::GpuHashError::Unknown => GpuError::Other(msg),
+        }
+    }
+}
+
+/// Check a GPU hash error result and convert to Result
+pub fn check_error(err: ffi::GpuHashError) -> GpuResult<()> {
+    if err == ffi::GpuHashError::Success {
+        Ok(())
+    } else {
+        Err(err.into())
+    }
+}

--- a/src/gpu/ffi.rs
+++ b/src/gpu/ffi.rs
@@ -1,0 +1,178 @@
+//! FFI bindings to the SYCL GPU hashing library
+//!
+//! This module provides low-level bindings to the C API defined in gpu_hash.h
+
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+use std::os::raw::{c_char, c_int, c_void};
+
+/// Hash algorithm identifiers
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuHashAlgorithm {
+    Sha256 = 0,
+    Sha384 = 1,
+    Sha512 = 2,
+}
+
+/// Error codes from the C library
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuHashError {
+    Success = 0,
+    NoDevice = 1,
+    InvalidAlgorithm = 2,
+    MemoryAllocation = 3,
+    KernelExecution = 4,
+    InvalidInput = 5,
+    NotInitialized = 6,
+    Unknown = 99,
+}
+
+/// Device type
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuDeviceType {
+    Gpu = 0,
+    Cpu = 1,
+    Accelerator = 2,
+}
+
+/// Device information structure
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct GpuDeviceInfo {
+    pub name: [c_char; 256],
+    pub vendor: [c_char; 256],
+    pub driver_version: [c_char; 64],
+    pub device_type: GpuDeviceType,
+    pub max_compute_units: u32,
+    pub global_memory_size: u64,
+    pub local_memory_size: u64,
+    pub max_work_group_size: usize,
+    pub is_intel: c_int,
+    pub is_intel_xe: c_int,
+}
+
+impl Default for GpuDeviceInfo {
+    fn default() -> Self {
+        Self {
+            name: [0; 256],
+            vendor: [0; 256],
+            driver_version: [0; 64],
+            device_type: GpuDeviceType::Gpu,
+            max_compute_units: 0,
+            global_memory_size: 0,
+            local_memory_size: 0,
+            max_work_group_size: 0,
+            is_intel: 0,
+            is_intel_xe: 0,
+        }
+    }
+}
+
+/// Opaque handle to GPU hasher context
+pub type GpuHashContextHandle = *mut c_void;
+
+// Link to the native library
+#[link(name = "gpu_hash")]
+unsafe extern "C" {
+    /// Initialize the GPU hashing library
+    pub fn gpu_hash_init() -> GpuHashError;
+
+    /// Cleanup the GPU hashing library
+    pub fn gpu_hash_cleanup();
+
+    /// Check if GPU hashing is available
+    pub fn gpu_hash_is_available() -> c_int;
+
+    /// Get the number of available GPU devices
+    pub fn gpu_hash_get_device_count() -> c_int;
+
+    /// Get information about a specific device
+    pub fn gpu_hash_get_device_info(device_index: c_int, info: *mut GpuDeviceInfo) -> GpuHashError;
+
+    /// Create a new hash context
+    pub fn gpu_hash_create_context(
+        algorithm: GpuHashAlgorithm,
+        device_index: c_int,
+        handle: *mut GpuHashContextHandle,
+    ) -> GpuHashError;
+
+    /// Destroy a hash context
+    pub fn gpu_hash_destroy_context(handle: GpuHashContextHandle);
+
+    /// Hash a single message
+    pub fn gpu_hash_single(
+        handle: GpuHashContextHandle,
+        input: *const u8,
+        input_len: usize,
+        output: *mut u8,
+        output_len: *mut usize,
+    ) -> GpuHashError;
+
+    /// Hash multiple messages in parallel
+    pub fn gpu_hash_batch(
+        handle: GpuHashContextHandle,
+        inputs: *const *const u8,
+        input_lens: *const usize,
+        num_inputs: usize,
+        outputs: *mut *mut u8,
+        output_size: usize,
+    ) -> GpuHashError;
+
+    /// Hash contiguous fixed-size messages
+    pub fn gpu_hash_batch_fixed(
+        handle: GpuHashContextHandle,
+        input: *const u8,
+        message_size: usize,
+        num_messages: usize,
+        output: *mut u8,
+    ) -> GpuHashError;
+
+    /// Get the output size for a hash algorithm
+    pub fn gpu_hash_output_size(algorithm: GpuHashAlgorithm) -> usize;
+
+    /// Get the last error message
+    pub fn gpu_hash_get_last_error() -> *const c_char;
+}
+
+/// Safe wrapper to get the last error message
+pub fn get_last_error_message() -> String {
+    unsafe {
+        let ptr = gpu_hash_get_last_error();
+        if ptr.is_null() {
+            String::new()
+        } else {
+            std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned()
+        }
+    }
+}
+
+/// Convert GpuDeviceInfo name field to String
+pub fn device_info_name(info: &GpuDeviceInfo) -> String {
+    unsafe {
+        std::ffi::CStr::from_ptr(info.name.as_ptr())
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+/// Convert GpuDeviceInfo vendor field to String
+pub fn device_info_vendor(info: &GpuDeviceInfo) -> String {
+    unsafe {
+        std::ffi::CStr::from_ptr(info.vendor.as_ptr())
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+/// Convert GpuDeviceInfo driver_version field to String
+pub fn device_info_driver_version(info: &GpuDeviceInfo) -> String {
+    unsafe {
+        std::ffi::CStr::from_ptr(info.driver_version.as_ptr())
+            .to_string_lossy()
+            .into_owned()
+    }
+}

--- a/src/gpu/hasher.rs
+++ b/src/gpu/hasher.rs
@@ -1,0 +1,470 @@
+//! GPU Hasher Implementation
+//!
+//! This module provides the main GpuHasher type for GPU-accelerated hashing.
+
+use super::context::GpuDevice;
+use super::error::{GpuError, GpuResult, check_error};
+use super::ffi;
+
+/// Supported hash algorithms for GPU hashing
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuHashAlgorithm {
+    /// SHA-256 (256-bit hash)
+    Sha256,
+    /// SHA-384 (384-bit hash)  
+    Sha384,
+    /// SHA-512 (512-bit hash)
+    Sha512,
+}
+
+impl GpuHashAlgorithm {
+    /// Get the output size in bytes for this algorithm
+    pub fn output_size(&self) -> usize {
+        match self {
+            GpuHashAlgorithm::Sha256 => 32,
+            GpuHashAlgorithm::Sha384 => 48,
+            GpuHashAlgorithm::Sha512 => 64,
+        }
+    }
+
+    /// Get the block size in bytes for this algorithm
+    pub fn block_size(&self) -> usize {
+        match self {
+            GpuHashAlgorithm::Sha256 => 64,
+            GpuHashAlgorithm::Sha384 | GpuHashAlgorithm::Sha512 => 128,
+        }
+    }
+
+    /// Convert to the cose::HashAlgorithm type
+    pub fn to_cose_algorithm(&self) -> crate::cose::HashAlgorithm {
+        match self {
+            GpuHashAlgorithm::Sha256 => crate::cose::HashAlgorithm::Sha256,
+            GpuHashAlgorithm::Sha384 => crate::cose::HashAlgorithm::Sha384,
+            GpuHashAlgorithm::Sha512 => crate::cose::HashAlgorithm::Sha512,
+        }
+    }
+
+    fn to_ffi(&self) -> ffi::GpuHashAlgorithm {
+        match self {
+            GpuHashAlgorithm::Sha256 => ffi::GpuHashAlgorithm::Sha256,
+            GpuHashAlgorithm::Sha384 => ffi::GpuHashAlgorithm::Sha384,
+            GpuHashAlgorithm::Sha512 => ffi::GpuHashAlgorithm::Sha512,
+        }
+    }
+}
+
+impl From<crate::cose::HashAlgorithm> for GpuHashAlgorithm {
+    fn from(alg: crate::cose::HashAlgorithm) -> Self {
+        match alg {
+            crate::cose::HashAlgorithm::Sha256 => GpuHashAlgorithm::Sha256,
+            crate::cose::HashAlgorithm::Sha384 => GpuHashAlgorithm::Sha384,
+            crate::cose::HashAlgorithm::Sha512 => GpuHashAlgorithm::Sha512,
+        }
+    }
+}
+
+impl std::str::FromStr for GpuHashAlgorithm {
+    type Err = GpuError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "sha256" | "sha-256" => Ok(GpuHashAlgorithm::Sha256),
+            "sha384" | "sha-384" => Ok(GpuHashAlgorithm::Sha384),
+            "sha512" | "sha-512" => Ok(GpuHashAlgorithm::Sha512),
+            _ => Err(GpuError::InvalidInput(format!(
+                "Unknown algorithm: {}. Supported: sha256, sha384, sha512",
+                s
+            ))),
+        }
+    }
+}
+
+/// Output from a hash operation
+#[derive(Debug, Clone)]
+pub struct HashOutput {
+    /// The hash bytes
+    bytes: Vec<u8>,
+    /// The algorithm used
+    algorithm: GpuHashAlgorithm,
+}
+
+impl HashOutput {
+    /// Create a new hash output
+    pub fn new(bytes: Vec<u8>, algorithm: GpuHashAlgorithm) -> Self {
+        Self { bytes, algorithm }
+    }
+
+    /// Get the hash bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Convert to a hex string
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.bytes)
+    }
+
+    /// Get the algorithm used
+    pub fn algorithm(&self) -> GpuHashAlgorithm {
+        self.algorithm
+    }
+
+    /// Consume and return the bytes
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl AsRef<[u8]> for HashOutput {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl std::fmt::Display for HashOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
+}
+
+/// GPU-accelerated hasher for Intel Xe GPUs
+pub struct GpuHasher {
+    algorithm: GpuHashAlgorithm,
+    handle: ffi::GpuHashContextHandle,
+    output_size: usize,
+}
+
+impl GpuHasher {
+    /// Create a new GPU hasher for the specified algorithm
+    ///
+    /// This will automatically select the best available Intel GPU.
+    ///
+    /// # Arguments
+    ///
+    /// * `algorithm` - The hash algorithm to use
+    ///
+    /// # Returns
+    ///
+    /// A new GpuHasher instance or an error if GPU is unavailable
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use atlas_c2pa_lib::gpu::{GpuHasher, GpuHashAlgorithm};
+    ///
+    /// let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+    /// ```
+    pub fn new(algorithm: GpuHashAlgorithm) -> GpuResult<Self> {
+        Self::new_with_device(algorithm, None)
+    }
+
+    /// Create a new GPU hasher with a specific device
+    ///
+    /// # Arguments
+    ///
+    /// * `algorithm` - The hash algorithm to use
+    /// * `device` - Optional device to use (None for auto-select)
+    pub fn new_with_device(
+        algorithm: GpuHashAlgorithm,
+        device: Option<&GpuDevice>,
+    ) -> GpuResult<Self> {
+        // Initialize the library
+        let err = unsafe { ffi::gpu_hash_init() };
+        check_error(err)?;
+
+        let device_index = device.map(|d| d.device_index()).unwrap_or(-1);
+        let mut handle: ffi::GpuHashContextHandle = std::ptr::null_mut();
+
+        let err =
+            unsafe { ffi::gpu_hash_create_context(algorithm.to_ffi(), device_index, &mut handle) };
+        check_error(err)?;
+
+        Ok(Self {
+            algorithm,
+            handle,
+            output_size: algorithm.output_size(),
+        })
+    }
+
+    /// Get the algorithm being used
+    pub fn algorithm(&self) -> GpuHashAlgorithm {
+        self.algorithm
+    }
+
+    /// Get the output size in bytes
+    pub fn output_size(&self) -> usize {
+        self.output_size
+    }
+
+    /// Hash a single message
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data to hash
+    ///
+    /// # Returns
+    ///
+    /// The hash as a byte vector
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+    /// let hash = hasher.hash(b"Hello, World!")?;
+    /// println!("Hash: {}", hex::encode(&hash));
+    /// ```
+    pub fn hash(&self, data: &[u8]) -> GpuResult<Vec<u8>> {
+        let mut output = vec![0u8; self.output_size];
+        let mut output_len = 0usize;
+
+        let err = unsafe {
+            ffi::gpu_hash_single(
+                self.handle,
+                data.as_ptr(),
+                data.len(),
+                output.as_mut_ptr(),
+                &mut output_len,
+            )
+        };
+        check_error(err)?;
+
+        Ok(output)
+    }
+
+    /// Hash a single message and return a HashOutput
+    pub fn hash_to_output(&self, data: &[u8]) -> GpuResult<HashOutput> {
+        let bytes = self.hash(data)?;
+        Ok(HashOutput::new(bytes, self.algorithm))
+    }
+
+    /// Hash multiple messages in parallel
+    ///
+    /// This is more efficient than calling hash() multiple times
+    /// when you have many messages to process.
+    ///
+    /// # Arguments
+    ///
+    /// * `messages` - Slice of messages to hash
+    ///
+    /// # Returns
+    ///
+    /// Vector of hashes, one per input message
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+    /// let messages = vec![
+    ///     b"Message 1".to_vec(),
+    ///     b"Message 2".to_vec(),
+    /// ];
+    /// let hashes = hasher.hash_batch(&messages)?;
+    /// ```
+    pub fn hash_batch(&self, messages: &[Vec<u8>]) -> GpuResult<Vec<Vec<u8>>> {
+        if messages.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let num_messages = messages.len();
+
+        // Prepare input pointers and lengths
+        let input_ptrs: Vec<*const u8> = messages.iter().map(|m| m.as_ptr()).collect();
+
+        let input_lens: Vec<usize> = messages.iter().map(|m| m.len()).collect();
+
+        // Prepare output buffers
+        let mut output_buffers: Vec<Vec<u8>> = (0..num_messages)
+            .map(|_| vec![0u8; self.output_size])
+            .collect();
+
+        let mut output_ptrs: Vec<*mut u8> =
+            output_buffers.iter_mut().map(|b| b.as_mut_ptr()).collect();
+
+        let err = unsafe {
+            ffi::gpu_hash_batch(
+                self.handle,
+                input_ptrs.as_ptr(),
+                input_lens.as_ptr(),
+                num_messages,
+                output_ptrs.as_mut_ptr(),
+                self.output_size,
+            )
+        };
+        check_error(err)?;
+
+        Ok(output_buffers)
+    }
+
+    /// Hash contiguous fixed-size messages
+    ///
+    /// This is the most efficient method when all messages have the same size.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - Contiguous buffer containing all messages
+    /// * `message_size` - Size of each individual message
+    ///
+    /// # Returns
+    ///
+    /// Vector of hashes, one per message
+    pub fn hash_batch_fixed(&self, data: &[u8], message_size: usize) -> GpuResult<Vec<Vec<u8>>> {
+        if message_size == 0 {
+            return Err(GpuError::InvalidInput(
+                "Message size cannot be zero".to_string(),
+            ));
+        }
+
+        if data.len() % message_size != 0 {
+            return Err(GpuError::InvalidInput(format!(
+                "Data length {} is not a multiple of message size {}",
+                data.len(),
+                message_size
+            )));
+        }
+
+        let num_messages = data.len() / message_size;
+        if num_messages == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut output = vec![0u8; self.output_size * num_messages];
+
+        let err = unsafe {
+            ffi::gpu_hash_batch_fixed(
+                self.handle,
+                data.as_ptr(),
+                message_size,
+                num_messages,
+                output.as_mut_ptr(),
+            )
+        };
+        check_error(err)?;
+
+        // Split output into individual hashes
+        let hashes: Vec<Vec<u8>> = output
+            .chunks(self.output_size)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+
+        Ok(hashes)
+    }
+
+    /// Hash a file from disk
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the file to hash
+    ///
+    /// # Returns
+    ///
+    /// The file hash as a byte vector
+    pub fn hash_file(&self, path: &std::path::Path) -> GpuResult<Vec<u8>> {
+        use std::fs::File;
+        use std::io::Read;
+
+        let mut file = File::open(path)
+            .map_err(|e| GpuError::InvalidInput(format!("Failed to open file: {}", e)))?;
+
+        let mut data = Vec::new();
+        file.read_to_end(&mut data)
+            .map_err(|e| GpuError::InvalidInput(format!("Failed to read file: {}", e)))?;
+
+        self.hash(&data)
+    }
+
+    /// Hash multiple files in parallel
+    ///
+    /// # Arguments
+    ///
+    /// * `paths` - Slice of file paths to hash
+    ///
+    /// # Returns
+    ///
+    /// Vector of hashes, one per file
+    pub fn hash_files(&self, paths: &[&std::path::Path]) -> GpuResult<Vec<Vec<u8>>> {
+        use std::fs::File;
+        use std::io::Read;
+
+        let mut messages = Vec::with_capacity(paths.len());
+
+        for path in paths {
+            let mut file = File::open(path).map_err(|e| {
+                GpuError::InvalidInput(format!("Failed to open file {:?}: {}", path, e))
+            })?;
+
+            let mut data = Vec::new();
+            file.read_to_end(&mut data).map_err(|e| {
+                GpuError::InvalidInput(format!("Failed to read file {:?}: {}", path, e))
+            })?;
+
+            messages.push(data);
+        }
+
+        self.hash_batch(&messages)
+    }
+}
+
+impl Drop for GpuHasher {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                ffi::gpu_hash_destroy_context(self.handle);
+            }
+        }
+    }
+}
+
+// GpuHasher is safe to send between threads as the underlying SYCL queue is thread-safe
+unsafe impl Send for GpuHasher {}
+
+impl std::fmt::Debug for GpuHasher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GpuHasher")
+            .field("algorithm", &self.algorithm)
+            .field("output_size", &self.output_size)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_algorithm_properties() {
+        assert_eq!(GpuHashAlgorithm::Sha256.output_size(), 32);
+        assert_eq!(GpuHashAlgorithm::Sha384.output_size(), 48);
+        assert_eq!(GpuHashAlgorithm::Sha512.output_size(), 64);
+
+        assert_eq!(GpuHashAlgorithm::Sha256.block_size(), 64);
+        assert_eq!(GpuHashAlgorithm::Sha384.block_size(), 128);
+        assert_eq!(GpuHashAlgorithm::Sha512.block_size(), 128);
+    }
+
+    #[test]
+    fn test_algorithm_from_str() {
+        assert_eq!(
+            "sha256".parse::<GpuHashAlgorithm>().unwrap(),
+            GpuHashAlgorithm::Sha256
+        );
+        assert_eq!(
+            "SHA256".parse::<GpuHashAlgorithm>().unwrap(),
+            GpuHashAlgorithm::Sha256
+        );
+        assert_eq!(
+            "sha-384".parse::<GpuHashAlgorithm>().unwrap(),
+            GpuHashAlgorithm::Sha384
+        );
+        assert!("invalid".parse::<GpuHashAlgorithm>().is_err());
+    }
+
+    #[test]
+    fn test_hash_output() {
+        let bytes = vec![0x01, 0x02, 0x03, 0x04];
+        let output = HashOutput::new(bytes.clone(), GpuHashAlgorithm::Sha256);
+
+        assert_eq!(output.as_bytes(), &bytes);
+        assert_eq!(output.to_hex(), "01020304");
+        assert_eq!(output.algorithm(), GpuHashAlgorithm::Sha256);
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,251 @@
+//! # GPU Hashing Module
+//!
+//! This module provides GPU-accelerated hashing using Intel Xe GPUs via SYCL/oneAPI.
+//! It supports SHA-256, SHA-384, and SHA-512 algorithms optimized for Intel discrete
+//! and integrated GPUs.
+//!
+//! ## Features
+//!
+//! - **Intel Xe GPU Support**: Optimized SYCL kernels for Intel Arc, Iris Xe, and UHD Graphics
+//! - **Multiple Algorithms**: SHA-256, SHA-384, SHA-512
+//! - **Batch Processing**: Efficient hashing of multiple messages in parallel
+//! - **Automatic Fallback**: Falls back to CPU hashing when GPU is unavailable
+//!
+//! ## Usage
+//!
+//! This module is only available when the `gpu-hashing` feature is enabled:
+//!
+//! ```toml
+//! [dependencies]
+//! atlas-c2pa-lib = { version = "0.1", features = ["gpu-hashing"] }
+//! ```
+//!
+//! ## Prerequisites
+//!
+//! - Intel oneAPI Base Toolkit (for DPC++/SYCL compiler)
+//! - Intel GPU drivers with Level Zero support
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use atlas_c2pa_lib::gpu::{GpuHasher, GpuHashAlgorithm};
+//!
+//! // Create a GPU hasher for SHA-256
+//! let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+//!
+//! // Hash a single message
+//! let hash = hasher.hash(b"Hello, World!")?;
+//!
+//! // Hash multiple messages in parallel
+//! let messages = vec![
+//!     b"Message 1".to_vec(),
+//!     b"Message 2".to_vec(),
+//!     b"Message 3".to_vec(),
+//! ];
+//! let hashes = hasher.hash_batch(&messages)?;
+//! ```
+
+mod context;
+mod error;
+mod ffi;
+mod hasher;
+
+pub use context::{GpuDevice, GpuDeviceType};
+pub use error::{GpuError, GpuResult};
+pub use hasher::{GpuHashAlgorithm, GpuHasher, HashOutput};
+
+/// Check if GPU hashing is available on this system
+///
+/// Returns `true` if an Intel GPU with SYCL support is detected.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use atlas_c2pa_lib::gpu::is_gpu_available;
+///
+/// if is_gpu_available() {
+///     println!("GPU hashing is available!");
+/// } else {
+///     println!("Falling back to CPU hashing");
+/// }
+/// ```
+pub fn is_gpu_available() -> bool {
+    unsafe { ffi::gpu_hash_is_available() != 0 }
+}
+
+/// Get information about available GPU devices
+///
+/// Returns a list of available Intel GPU devices that support SYCL.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use atlas_c2pa_lib::gpu::get_available_devices;
+///
+/// for device in get_available_devices()? {
+///     println!("Found device: {} ({})", device.name(), device.vendor());
+/// }
+/// ```
+pub fn get_available_devices() -> GpuResult<Vec<GpuDevice>> {
+    context::get_available_devices()
+}
+
+/// Convenience function to hash data using GPU if available, CPU otherwise
+///
+/// This function automatically selects the best available method for hashing.
+/// If an Intel GPU is available, it uses GPU acceleration. Otherwise, it falls
+/// back to CPU-based hashing using the ring crate.
+///
+/// # Arguments
+///
+/// * `data` - The data to hash
+/// * `algorithm` - The hash algorithm to use
+///
+/// # Returns
+///
+/// The hash as a byte vector
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use atlas_c2pa_lib::gpu::{hash_auto, GpuHashAlgorithm};
+///
+/// let hash = hash_auto(b"Hello, World!", GpuHashAlgorithm::Sha256)?;
+/// println!("Hash: {}", hex::encode(&hash));
+/// ```
+pub fn hash_auto(data: &[u8], algorithm: GpuHashAlgorithm) -> GpuResult<Vec<u8>> {
+    if is_gpu_available() {
+        let hasher = GpuHasher::new(algorithm)?;
+        hasher.hash(data)
+    } else {
+        // Fallback to CPU hashing
+        Ok(hash_cpu(data, algorithm))
+    }
+}
+
+/// Hash data using CPU (fallback implementation)
+fn hash_cpu(data: &[u8], algorithm: GpuHashAlgorithm) -> Vec<u8> {
+    use ring::digest;
+
+    let algorithm = match algorithm {
+        GpuHashAlgorithm::Sha256 => &digest::SHA256,
+        GpuHashAlgorithm::Sha384 => &digest::SHA384,
+        GpuHashAlgorithm::Sha512 => &digest::SHA512,
+    };
+
+    digest::digest(algorithm, data).as_ref().to_vec()
+}
+
+/// Batch hash multiple messages using GPU if available
+///
+/// This is more efficient than hashing messages one by one when you have
+/// many messages to process.
+///
+/// # Arguments
+///
+/// * `messages` - Slice of messages to hash
+/// * `algorithm` - The hash algorithm to use
+///
+/// # Returns
+///
+/// Vector of hashes, one per input message
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use atlas_c2pa_lib::gpu::{hash_batch_auto, GpuHashAlgorithm};
+///
+/// let messages = vec![
+///     b"Message 1".to_vec(),
+///     b"Message 2".to_vec(),
+///     b"Message 3".to_vec(),
+/// ];
+///
+/// let hashes = hash_batch_auto(&messages, GpuHashAlgorithm::Sha256)?;
+/// for (i, hash) in hashes.iter().enumerate() {
+///     println!("Message {} hash: {}", i, hex::encode(hash));
+/// }
+/// ```
+pub fn hash_batch_auto(
+    messages: &[Vec<u8>],
+    algorithm: GpuHashAlgorithm,
+) -> GpuResult<Vec<Vec<u8>>> {
+    if is_gpu_available() && messages.len() > 1 {
+        let hasher = GpuHasher::new(algorithm)?;
+        hasher.hash_batch(messages)
+    } else {
+        // Fallback to CPU hashing
+        Ok(messages
+            .iter()
+            .map(|msg| hash_cpu(msg, algorithm))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gpu_availability_check() {
+        // This test just ensures the availability check doesn't panic
+        let _ = is_gpu_available();
+    }
+
+    #[test]
+    fn test_hash_auto_sha256() {
+        let data = b"Hello, World!";
+        let result = hash_auto(data, GpuHashAlgorithm::Sha256);
+        assert!(result.is_ok());
+        let hash = result.unwrap();
+        assert_eq!(hash.len(), 32); // SHA-256 produces 32 bytes
+    }
+
+    #[test]
+    fn test_hash_auto_sha384() {
+        let data = b"Hello, World!";
+        let result = hash_auto(data, GpuHashAlgorithm::Sha384);
+        assert!(result.is_ok());
+        let hash = result.unwrap();
+        assert_eq!(hash.len(), 48); // SHA-384 produces 48 bytes
+    }
+
+    #[test]
+    fn test_hash_auto_sha512() {
+        let data = b"Hello, World!";
+        let result = hash_auto(data, GpuHashAlgorithm::Sha512);
+        assert!(result.is_ok());
+        let hash = result.unwrap();
+        assert_eq!(hash.len(), 64); // SHA-512 produces 64 bytes
+    }
+
+    #[test]
+    fn test_batch_hash() {
+        let messages = vec![
+            b"Message 1".to_vec(),
+            b"Message 2".to_vec(),
+            b"Message 3".to_vec(),
+        ];
+
+        let result = hash_batch_auto(&messages, GpuHashAlgorithm::Sha256);
+        assert!(result.is_ok());
+        let hashes = result.unwrap();
+        assert_eq!(hashes.len(), 3);
+
+        // Verify each hash has correct length
+        for hash in hashes {
+            assert_eq!(hash.len(), 32);
+        }
+    }
+
+    #[test]
+    fn test_known_sha256_vector() {
+        // Test vector: SHA-256 of empty string
+        let data = b"";
+        let result = hash_auto(data, GpuHashAlgorithm::Sha256).unwrap();
+        let expected =
+            hex::decode("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+                .unwrap();
+        assert_eq!(result, expected);
+    }
+}

--- a/src/gpu/sycl/gpu_hash.cpp
+++ b/src/gpu/sycl/gpu_hash.cpp
@@ -1,838 +1,1041 @@
-/**
- * @file gpu_hash.cpp
- * @brief SYCL implementation of GPU-accelerated hashing for Intel Xe GPUs
- * 
- * This file implements SHA-256, SHA-384, and SHA-512 hashing using Intel SYCL.
- * Optimized for Intel Arc, Iris Xe, and UHD Graphics.
- * 
- * Compile with:
- *   icpx -fsycl -shared -fPIC -O3 -o libgpu_hash.so gpu_hash.cpp
- * 
- * Or for specific Intel GPU targets:
- *   icpx -fsycl -fsycl-targets=intel_gpu_pvc,intel_gpu_dg2 -shared -fPIC -O3 -o libgpu_hash.so gpu_hash.cpp
- */
-
 #include "gpu_hash.h"
+#include <algorithm>
+#include <cstring>
+#include <mutex>
 #include <sycl/sycl.hpp>
 #include <vector>
-#include <memory>
-#include <mutex>
-#include <cstring>
-#include <algorithm>
-
-// ============================================================================
-// SHA-256 Constants and Functions
-// ============================================================================
 
 namespace {
 
-// SHA-256 round constants
+// Constants in constant memory
 constexpr uint32_t K256[64] = {
-    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
-};
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
 
-// SHA-256 initial hash values
-constexpr uint32_t H256_INIT[8] = {
-    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
-};
+constexpr uint32_t H256_INIT[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372,
+                                   0xa54ff53a, 0x510e527f, 0x9b05688c,
+                                   0x1f83d9ab, 0x5be0cd19};
 
-// SHA-512 round constants
 constexpr uint64_t K512[80] = {
-    0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
-    0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL, 0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL,
-    0xd807aa98a3030242ULL, 0x12835b0145706fbeULL, 0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL,
-    0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL, 0x9bdc06a725c71235ULL, 0xc19bf174cf692694ULL,
-    0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL, 0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
-    0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL, 0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL,
-    0x983e5152ee66dfabULL, 0xa831c66d2db43210ULL, 0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL,
-    0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL, 0x06ca6351e003826fULL, 0x142929670a0e6e70ULL,
-    0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL, 0x4d2c6dfc5ac42aedULL, 0x53380d139d95b3dfULL,
-    0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL, 0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
-    0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL, 0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL,
-    0xd192e819d6ef5218ULL, 0xd69906245565a910ULL, 0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL,
-    0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL, 0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL,
-    0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL, 0x5b9cca4f7763e373ULL, 0x682e6ff3d6b2b8a3ULL,
-    0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL, 0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
-    0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL, 0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL,
-    0xca273eceea26619cULL, 0xd186b8c721c0c207ULL, 0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL,
-    0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL, 0x113f9804bef90daeULL, 0x1b710b35131c471bULL,
-    0x28db77f523047d84ULL, 0x32caab7b40c72493ULL, 0x3c9ebe0a15c9bebcULL, 0x431d67c49c100d4cULL,
-    0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL, 0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
-};
+    0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL,
+    0xe9b5dba58189dbbcULL, 0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL,
+    0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL, 0xd807aa98a3030242ULL,
+    0x12835b0145706fbeULL, 0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL,
+    0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL, 0x9bdc06a725c71235ULL,
+    0xc19bf174cf692694ULL, 0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL,
+    0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL, 0x2de92c6f592b0275ULL,
+    0x4a7484aa6ea6e483ULL, 0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL,
+    0x983e5152ee66dfabULL, 0xa831c66d2db43210ULL, 0xb00327c898fb213fULL,
+    0xbf597fc7beef0ee4ULL, 0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL,
+    0x06ca6351e003826fULL, 0x142929670a0e6e70ULL, 0x27b70a8546d22ffcULL,
+    0x2e1b21385c26c926ULL, 0x4d2c6dfc5ac42aedULL, 0x53380d139d95b3dfULL,
+    0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL, 0x81c2c92e47edaee6ULL,
+    0x92722c851482353bULL, 0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL,
+    0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL, 0xd192e819d6ef5218ULL,
+    0xd69906245565a910ULL, 0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL,
+    0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL, 0x2748774cdf8eeb99ULL,
+    0x34b0bcb5e19b48a8ULL, 0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL,
+    0x5b9cca4f7763e373ULL, 0x682e6ff3d6b2b8a3ULL, 0x748f82ee5defb2fcULL,
+    0x78a5636f43172f60ULL, 0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
+    0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL, 0xbef9a3f7b2c67915ULL,
+    0xc67178f2e372532bULL, 0xca273eceea26619cULL, 0xd186b8c721c0c207ULL,
+    0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL, 0x06f067aa72176fbaULL,
+    0x0a637dc5a2c898a6ULL, 0x113f9804bef90daeULL, 0x1b710b35131c471bULL,
+    0x28db77f523047d84ULL, 0x32caab7b40c72493ULL, 0x3c9ebe0a15c9bebcULL,
+    0x431d67c49c100d4cULL, 0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL,
+    0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL};
 
-// SHA-512 initial values
 constexpr uint64_t H512_INIT[8] = {
-    0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
-    0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL, 0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
-};
+    0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL,
+    0xa54ff53a5f1d36f1ULL, 0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL,
+    0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL};
 
-// SHA-384 initial values
 constexpr uint64_t H384_INIT[8] = {
-    0xcbbb9d5dc1059ed8ULL, 0x629a292a367cd507ULL, 0x9159015a3070dd17ULL, 0x152fecd8f70e5939ULL,
-    0x67332667ffc00b31ULL, 0x8eb44a8768581511ULL, 0xdb0c2e0d64f98fa7ULL, 0x47b5481dbefa4fa4ULL
-};
+    0xcbbb9d5dc1059ed8ULL, 0x629a292a367cd507ULL, 0x9159015a3070dd17ULL,
+    0x152fecd8f70e5939ULL, 0x67332667ffc00b31ULL, 0x8eb44a8768581511ULL,
+    0xdb0c2e0d64f98fa7ULL, 0x47b5481dbefa4fa4ULL};
 
-// Bitwise operations
-inline uint32_t rotr32(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
-inline uint64_t rotr64(uint64_t x, int n) { return (x >> n) | (x << (64 - n)); }
-
-// SHA-256 functions
-inline uint32_t ch32(uint32_t x, uint32_t y, uint32_t z) { return (x & y) ^ (~x & z); }
-inline uint32_t maj32(uint32_t x, uint32_t y, uint32_t z) { return (x & y) ^ (x & z) ^ (y & z); }
-inline uint32_t sigma0_256(uint32_t x) { return rotr32(x, 2) ^ rotr32(x, 13) ^ rotr32(x, 22); }
-inline uint32_t sigma1_256(uint32_t x) { return rotr32(x, 6) ^ rotr32(x, 11) ^ rotr32(x, 25); }
-inline uint32_t gamma0_256(uint32_t x) { return rotr32(x, 7) ^ rotr32(x, 18) ^ (x >> 3); }
-inline uint32_t gamma1_256(uint32_t x) { return rotr32(x, 17) ^ rotr32(x, 19) ^ (x >> 10); }
-
-// SHA-512 functions
-inline uint64_t ch64(uint64_t x, uint64_t y, uint64_t z) { return (x & y) ^ (~x & z); }
-inline uint64_t maj64(uint64_t x, uint64_t y, uint64_t z) { return (x & y) ^ (x & z) ^ (y & z); }
-inline uint64_t sigma0_512(uint64_t x) { return rotr64(x, 28) ^ rotr64(x, 34) ^ rotr64(x, 39); }
-inline uint64_t sigma1_512(uint64_t x) { return rotr64(x, 14) ^ rotr64(x, 18) ^ rotr64(x, 41); }
-inline uint64_t gamma0_512(uint64_t x) { return rotr64(x, 1) ^ rotr64(x, 8) ^ (x >> 7); }
-inline uint64_t gamma1_512(uint64_t x) { return rotr64(x, 19) ^ rotr64(x, 61) ^ (x >> 6); }
-
-// Thread-local error message
 thread_local std::string g_last_error;
-
-// Global state
 std::mutex g_init_mutex;
 bool g_initialized = false;
 std::vector<sycl::device> g_devices;
 
-} // anonymous namespace
-
-// ============================================================================
-// Hash Context Structure
-// ============================================================================
+} // namespace
 
 struct GpuHashContext {
-    GpuHashAlgorithm algorithm;
-    sycl::queue queue;
-    size_t output_size;
-    
-    GpuHashContext(GpuHashAlgorithm alg, sycl::queue q)
-        : algorithm(alg), queue(std::move(q)) {
-        switch (alg) {
-            case GPU_HASH_SHA256: output_size = 32; break;
-            case GPU_HASH_SHA384: output_size = 48; break;
-            case GPU_HASH_SHA512: output_size = 64; break;
-            default: output_size = 32;
-        }
-    }
+  GpuHashAlgorithm algorithm;
+  sycl::queue queue;
+  size_t output_size;
+
+  // Persistent device buffers for constants (avoid re-uploading)
+  uint32_t *d_K256 = nullptr;
+  uint32_t *d_H256 = nullptr;
+  uint64_t *d_K512 = nullptr;
+  uint64_t *d_H512 = nullptr;
+  uint64_t *d_H384 = nullptr;
+
+  GpuHashContext(GpuHashAlgorithm alg, sycl::queue q)
+      : algorithm(alg), queue(std::move(q)) {
+    output_size = (alg == GPU_HASH_SHA256)   ? 32
+                  : (alg == GPU_HASH_SHA384) ? 48
+                                             : 64;
+
+    // Pre-allocate constants on device
+    d_K256 = sycl::malloc_device<uint32_t>(64, queue);
+    d_H256 = sycl::malloc_device<uint32_t>(8, queue);
+    d_K512 = sycl::malloc_device<uint64_t>(80, queue);
+    d_H512 = sycl::malloc_device<uint64_t>(8, queue);
+    d_H384 = sycl::malloc_device<uint64_t>(8, queue);
+
+    queue.memcpy(d_K256, K256, 64 * sizeof(uint32_t));
+    queue.memcpy(d_H256, H256_INIT, 8 * sizeof(uint32_t));
+    queue.memcpy(d_K512, K512, 80 * sizeof(uint64_t));
+    queue.memcpy(d_H512, H512_INIT, 8 * sizeof(uint64_t));
+    queue.memcpy(d_H384, H384_INIT, 8 * sizeof(uint64_t));
+    queue.wait();
+  }
+
+  ~GpuHashContext() {
+    if (d_K256)
+      sycl::free(d_K256, queue);
+    if (d_H256)
+      sycl::free(d_H256, queue);
+    if (d_K512)
+      sycl::free(d_K512, queue);
+    if (d_H512)
+      sycl::free(d_H512, queue);
+    if (d_H384)
+      sycl::free(d_H384, queue);
+  }
 };
 
-// ============================================================================
-// SYCL Kernels
-// ============================================================================
+// CPU SHA-256 fallback
+static void sha256_cpu(const uint8_t *input, size_t len, uint8_t *output) {
+  uint32_t state[8];
+  for (int i = 0; i < 8; i++)
+    state[i] = H256_INIT[i];
 
-// SHA-256 kernel for batch processing
-class Sha256BatchKernel;
+  auto rotr = [](uint32_t x, uint32_t n) { return (x >> n) | (x << (32 - n)); };
 
-void sha256_hash_batch(
-    sycl::queue& q,
-    const uint8_t* input,
-    const uint64_t* offsets,
-    const uint64_t* lengths,
-    uint8_t* output,
-    size_t num_messages
-) {
-    // Copy constants to device
-    sycl::buffer<uint32_t, 1> k_buf(K256, sycl::range<1>(64));
-    sycl::buffer<uint32_t, 1> h_buf(H256_INIT, sycl::range<1>(8));
-    
-    q.submit([&](sycl::handler& h) {
-        auto k_acc = k_buf.get_access<sycl::access::mode::read>(h);
-        auto h_acc = h_buf.get_access<sycl::access::mode::read>(h);
-        
-        h.parallel_for<Sha256BatchKernel>(
-            sycl::range<1>(num_messages),
-            [=](sycl::id<1> idx) {
-                size_t msg_idx = idx[0];
-                uint64_t msg_offset = offsets[msg_idx];
-                uint64_t msg_len = lengths[msg_idx];
-                
-                // Initialize state
-                uint32_t state[8];
-                for (int i = 0; i < 8; i++) {
-                    state[i] = h_acc[i];
-                }
-                
-                // Process full blocks
-                uint64_t num_blocks = msg_len / 64;
-                for (uint64_t b = 0; b < num_blocks; b++) {
-                    uint32_t W[64];
-                    
-                    // Load block
-                    for (int i = 0; i < 16; i++) {
-                        uint64_t pos = msg_offset + b * 64 + i * 4;
-                        W[i] = ((uint32_t)input[pos] << 24) |
-                               ((uint32_t)input[pos + 1] << 16) |
-                               ((uint32_t)input[pos + 2] << 8) |
-                               (uint32_t)input[pos + 3];
-                    }
-                    
-                    // Extend
-                    for (int i = 16; i < 64; i++) {
-                        W[i] = gamma1_256(W[i-2]) + W[i-7] + gamma0_256(W[i-15]) + W[i-16];
-                    }
-                    
-                    // Compress
-                    uint32_t a = state[0], bb = state[1], c = state[2], d = state[3];
-                    uint32_t e = state[4], f = state[5], g = state[6], hh = state[7];
-                    
-                    for (int i = 0; i < 64; i++) {
-                        uint32_t T1 = hh + sigma1_256(e) + ch32(e, f, g) + k_acc[i] + W[i];
-                        uint32_t T2 = sigma0_256(a) + maj32(a, bb, c);
-                        hh = g; g = f; f = e; e = d + T1;
-                        d = c; c = bb; bb = a; a = T1 + T2;
-                    }
-                    
-                    state[0] += a; state[1] += bb; state[2] += c; state[3] += d;
-                    state[4] += e; state[5] += f; state[6] += g; state[7] += hh;
-                }
-                
-                // Handle padding
-                uint8_t padded[128] = {0};
-                uint32_t remaining = msg_len % 64;
-                uint32_t pad_blocks = (remaining < 56) ? 1 : 2;
-                
-                // Copy remaining bytes
-                for (uint32_t i = 0; i < remaining; i++) {
-                    padded[i] = input[msg_offset + num_blocks * 64 + i];
-                }
-                padded[remaining] = 0x80;
-                
-                // Add length
-                uint64_t bit_len = msg_len * 8;
-                uint32_t len_offset = (pad_blocks == 1) ? 56 : 120;
-                padded[len_offset] = (bit_len >> 56) & 0xff;
-                padded[len_offset + 1] = (bit_len >> 48) & 0xff;
-                padded[len_offset + 2] = (bit_len >> 40) & 0xff;
-                padded[len_offset + 3] = (bit_len >> 32) & 0xff;
-                padded[len_offset + 4] = (bit_len >> 24) & 0xff;
-                padded[len_offset + 5] = (bit_len >> 16) & 0xff;
-                padded[len_offset + 6] = (bit_len >> 8) & 0xff;
-                padded[len_offset + 7] = bit_len & 0xff;
-                
-                // Process padding blocks
-                for (uint32_t p = 0; p < pad_blocks; p++) {
-                    uint32_t W[64];
-                    for (int i = 0; i < 16; i++) {
-                        W[i] = ((uint32_t)padded[p * 64 + i * 4] << 24) |
-                               ((uint32_t)padded[p * 64 + i * 4 + 1] << 16) |
-                               ((uint32_t)padded[p * 64 + i * 4 + 2] << 8) |
-                               (uint32_t)padded[p * 64 + i * 4 + 3];
-                    }
-                    
-                    for (int i = 16; i < 64; i++) {
-                        W[i] = gamma1_256(W[i-2]) + W[i-7] + gamma0_256(W[i-15]) + W[i-16];
-                    }
-                    
-                    uint32_t a = state[0], bb = state[1], c = state[2], d = state[3];
-                    uint32_t e = state[4], f = state[5], g = state[6], hh = state[7];
-                    
-                    for (int i = 0; i < 64; i++) {
-                        uint32_t T1 = hh + sigma1_256(e) + ch32(e, f, g) + k_acc[i] + W[i];
-                        uint32_t T2 = sigma0_256(a) + maj32(a, bb, c);
-                        hh = g; g = f; f = e; e = d + T1;
-                        d = c; c = bb; bb = a; a = T1 + T2;
-                    }
-                    
-                    state[0] += a; state[1] += bb; state[2] += c; state[3] += d;
-                    state[4] += e; state[5] += f; state[6] += g; state[7] += hh;
-                }
-                
-                // Write output
-                size_t out_offset = msg_idx * 32;
-                for (int i = 0; i < 8; i++) {
-                    output[out_offset + i * 4] = (state[i] >> 24) & 0xff;
-                    output[out_offset + i * 4 + 1] = (state[i] >> 16) & 0xff;
-                    output[out_offset + i * 4 + 2] = (state[i] >> 8) & 0xff;
-                    output[out_offset + i * 4 + 3] = state[i] & 0xff;
-                }
-            }
-        );
-    }).wait();
+  size_t num_blocks = len / 64;
+  for (size_t b = 0; b < num_blocks; b++) {
+    uint32_t W[64];
+    for (int i = 0; i < 16; i++) {
+      size_t pos = b * 64 + i * 4;
+      W[i] = ((uint32_t)input[pos] << 24) | ((uint32_t)input[pos + 1] << 16) |
+             ((uint32_t)input[pos + 2] << 8) | (uint32_t)input[pos + 3];
+    }
+    for (int i = 16; i < 64; i++) {
+      uint32_t s0 = rotr(W[i - 15], 7) ^ rotr(W[i - 15], 18) ^ (W[i - 15] >> 3);
+      uint32_t s1 = rotr(W[i - 2], 17) ^ rotr(W[i - 2], 19) ^ (W[i - 2] >> 10);
+      W[i] = W[i - 16] + s0 + W[i - 7] + s1;
+    }
+    uint32_t a = state[0], bb = state[1], c = state[2], d = state[3];
+    uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+    for (int i = 0; i < 64; i++) {
+      uint32_t S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      uint32_t ch = (e & f) ^ (~e & g);
+      uint32_t T1 = h + S1 + ch + K256[i] + W[i];
+      uint32_t S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      uint32_t maj = (a & bb) ^ (a & c) ^ (bb & c);
+      uint32_t T2 = S0 + maj;
+      h = g;
+      g = f;
+      f = e;
+      e = d + T1;
+      d = c;
+      c = bb;
+      bb = a;
+      a = T1 + T2;
+    }
+    state[0] += a;
+    state[1] += bb;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    state[5] += f;
+    state[6] += g;
+    state[7] += h;
+  }
+
+  uint8_t padded[128] = {0};
+  size_t remaining = len % 64;
+  size_t pad_blocks = (remaining < 56) ? 1 : 2;
+  for (size_t i = 0; i < remaining; i++)
+    padded[i] = input[num_blocks * 64 + i];
+  padded[remaining] = 0x80;
+  uint64_t bit_len = len * 8;
+  size_t len_offset = (pad_blocks == 1) ? 56 : 120;
+  for (int i = 0; i < 8; i++)
+    padded[len_offset + i] = (bit_len >> (56 - i * 8)) & 0xff;
+
+  for (size_t p = 0; p < pad_blocks; p++) {
+    uint32_t W[64];
+    for (int i = 0; i < 16; i++) {
+      W[i] = ((uint32_t)padded[p * 64 + i * 4] << 24) |
+             ((uint32_t)padded[p * 64 + i * 4 + 1] << 16) |
+             ((uint32_t)padded[p * 64 + i * 4 + 2] << 8) |
+             (uint32_t)padded[p * 64 + i * 4 + 3];
+    }
+    for (int i = 16; i < 64; i++) {
+      uint32_t s0 = rotr(W[i - 15], 7) ^ rotr(W[i - 15], 18) ^ (W[i - 15] >> 3);
+      uint32_t s1 = rotr(W[i - 2], 17) ^ rotr(W[i - 2], 19) ^ (W[i - 2] >> 10);
+      W[i] = W[i - 16] + s0 + W[i - 7] + s1;
+    }
+    uint32_t a = state[0], bb = state[1], c = state[2], d = state[3];
+    uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+    for (int i = 0; i < 64; i++) {
+      uint32_t S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      uint32_t ch = (e & f) ^ (~e & g);
+      uint32_t T1 = h + S1 + ch + K256[i] + W[i];
+      uint32_t S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      uint32_t maj = (a & bb) ^ (a & c) ^ (bb & c);
+      uint32_t T2 = S0 + maj;
+      h = g;
+      g = f;
+      f = e;
+      e = d + T1;
+      d = c;
+      c = bb;
+      bb = a;
+      a = T1 + T2;
+    }
+    state[0] += a;
+    state[1] += bb;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    state[5] += f;
+    state[6] += g;
+    state[7] += h;
+  }
+
+  for (int i = 0; i < 8; i++) {
+    output[i * 4] = (state[i] >> 24) & 0xff;
+    output[i * 4 + 1] = (state[i] >> 16) & 0xff;
+    output[i * 4 + 2] = (state[i] >> 8) & 0xff;
+    output[i * 4 + 3] = state[i] & 0xff;
+  }
 }
 
-// SHA-512/384 kernel
-class Sha512BatchKernel;
+// CPU SHA-512/384 fallback
+static void sha512_cpu(const uint8_t *input, size_t len, uint8_t *output,
+                       bool is_sha384) {
+  uint64_t state[8];
+  const uint64_t *init = is_sha384 ? H384_INIT : H512_INIT;
+  for (int i = 0; i < 8; i++)
+    state[i] = init[i];
 
-void sha512_hash_batch(
-    sycl::queue& q,
-    const uint8_t* input,
-    const uint64_t* offsets,
-    const uint64_t* lengths,
-    uint8_t* output,
-    size_t num_messages,
-    bool is_sha384
-) {
-    sycl::buffer<uint64_t, 1> k_buf(K512, sycl::range<1>(80));
-    sycl::buffer<uint64_t, 1> h_buf(is_sha384 ? H384_INIT : H512_INIT, sycl::range<1>(8));
-    
-    size_t output_words = is_sha384 ? 6 : 8;
-    size_t output_bytes = is_sha384 ? 48 : 64;
-    
-    q.submit([&](sycl::handler& h) {
-        auto k_acc = k_buf.get_access<sycl::access::mode::read>(h);
-        auto h_acc = h_buf.get_access<sycl::access::mode::read>(h);
-        
-        h.parallel_for<Sha512BatchKernel>(
-            sycl::range<1>(num_messages),
-            [=](sycl::id<1> idx) {
-                size_t msg_idx = idx[0];
-                uint64_t msg_offset = offsets[msg_idx];
-                uint64_t msg_len = lengths[msg_idx];
-                
-                // Initialize state
-                uint64_t state[8];
-                for (int i = 0; i < 8; i++) {
-                    state[i] = h_acc[i];
-                }
-                
-                // Process full 128-byte blocks
-                uint64_t num_blocks = msg_len / 128;
-                for (uint64_t b = 0; b < num_blocks; b++) {
-                    uint64_t W[80];
-                    
-                    for (int i = 0; i < 16; i++) {
-                        uint64_t pos = msg_offset + b * 128 + i * 8;
-                        W[i] = ((uint64_t)input[pos] << 56) |
-                               ((uint64_t)input[pos + 1] << 48) |
-                               ((uint64_t)input[pos + 2] << 40) |
-                               ((uint64_t)input[pos + 3] << 32) |
-                               ((uint64_t)input[pos + 4] << 24) |
-                               ((uint64_t)input[pos + 5] << 16) |
-                               ((uint64_t)input[pos + 6] << 8) |
-                               (uint64_t)input[pos + 7];
-                    }
-                    
-                    for (int i = 16; i < 80; i++) {
-                        W[i] = gamma1_512(W[i-2]) + W[i-7] + gamma0_512(W[i-15]) + W[i-16];
-                    }
-                    
-                    uint64_t a = state[0], bb = state[1], c = state[2], d = state[3];
-                    uint64_t e = state[4], f = state[5], g = state[6], hh = state[7];
-                    
-                    for (int i = 0; i < 80; i++) {
-                        uint64_t T1 = hh + sigma1_512(e) + ch64(e, f, g) + k_acc[i] + W[i];
-                        uint64_t T2 = sigma0_512(a) + maj64(a, bb, c);
-                        hh = g; g = f; f = e; e = d + T1;
-                        d = c; c = bb; bb = a; a = T1 + T2;
-                    }
-                    
-                    state[0] += a; state[1] += bb; state[2] += c; state[3] += d;
-                    state[4] += e; state[5] += f; state[6] += g; state[7] += hh;
-                }
-                
-                // Handle padding
-                uint8_t padded[256] = {0};
-                uint64_t remaining = msg_len % 128;
-                uint32_t pad_blocks = (remaining < 112) ? 1 : 2;
-                
-                for (uint64_t i = 0; i < remaining; i++) {
-                    padded[i] = input[msg_offset + num_blocks * 128 + i];
-                }
-                padded[remaining] = 0x80;
-                
-                // Add 128-bit length (we only use lower 64 bits)
-                uint64_t bit_len = msg_len * 8;
-                uint32_t len_offset = (pad_blocks == 1) ? 112 : 240;
-                // Upper 64 bits = 0
-                for (int i = 0; i < 8; i++) padded[len_offset + i] = 0;
-                // Lower 64 bits
-                padded[len_offset + 8] = (bit_len >> 56) & 0xff;
-                padded[len_offset + 9] = (bit_len >> 48) & 0xff;
-                padded[len_offset + 10] = (bit_len >> 40) & 0xff;
-                padded[len_offset + 11] = (bit_len >> 32) & 0xff;
-                padded[len_offset + 12] = (bit_len >> 24) & 0xff;
-                padded[len_offset + 13] = (bit_len >> 16) & 0xff;
-                padded[len_offset + 14] = (bit_len >> 8) & 0xff;
-                padded[len_offset + 15] = bit_len & 0xff;
-                
-                for (uint32_t p = 0; p < pad_blocks; p++) {
-                    uint64_t W[80];
-                    for (int i = 0; i < 16; i++) {
-                        W[i] = ((uint64_t)padded[p * 128 + i * 8] << 56) |
-                               ((uint64_t)padded[p * 128 + i * 8 + 1] << 48) |
-                               ((uint64_t)padded[p * 128 + i * 8 + 2] << 40) |
-                               ((uint64_t)padded[p * 128 + i * 8 + 3] << 32) |
-                               ((uint64_t)padded[p * 128 + i * 8 + 4] << 24) |
-                               ((uint64_t)padded[p * 128 + i * 8 + 5] << 16) |
-                               ((uint64_t)padded[p * 128 + i * 8 + 6] << 8) |
-                               (uint64_t)padded[p * 128 + i * 8 + 7];
-                    }
-                    
-                    for (int i = 16; i < 80; i++) {
-                        W[i] = gamma1_512(W[i-2]) + W[i-7] + gamma0_512(W[i-15]) + W[i-16];
-                    }
-                    
-                    uint64_t a = state[0], bb = state[1], c = state[2], d = state[3];
-                    uint64_t e = state[4], f = state[5], g = state[6], hh = state[7];
-                    
-                    for (int i = 0; i < 80; i++) {
-                        uint64_t T1 = hh + sigma1_512(e) + ch64(e, f, g) + k_acc[i] + W[i];
-                        uint64_t T2 = sigma0_512(a) + maj64(a, bb, c);
-                        hh = g; g = f; f = e; e = d + T1;
-                        d = c; c = bb; bb = a; a = T1 + T2;
-                    }
-                    
-                    state[0] += a; state[1] += bb; state[2] += c; state[3] += d;
-                    state[4] += e; state[5] += f; state[6] += g; state[7] += hh;
-                }
-                
-                // Write output
-                size_t out_offset = msg_idx * output_bytes;
-                for (size_t i = 0; i < output_words; i++) {
-                    output[out_offset + i * 8] = (state[i] >> 56) & 0xff;
-                    output[out_offset + i * 8 + 1] = (state[i] >> 48) & 0xff;
-                    output[out_offset + i * 8 + 2] = (state[i] >> 40) & 0xff;
-                    output[out_offset + i * 8 + 3] = (state[i] >> 32) & 0xff;
-                    output[out_offset + i * 8 + 4] = (state[i] >> 24) & 0xff;
-                    output[out_offset + i * 8 + 5] = (state[i] >> 16) & 0xff;
-                    output[out_offset + i * 8 + 6] = (state[i] >> 8) & 0xff;
-                    output[out_offset + i * 8 + 7] = state[i] & 0xff;
-                }
-            }
-        );
-    }).wait();
+  auto rotr = [](uint64_t x, uint64_t n) { return (x >> n) | (x << (64 - n)); };
+
+  size_t num_blocks = len / 128;
+  for (size_t b = 0; b < num_blocks; b++) {
+    uint64_t W[80];
+    for (int i = 0; i < 16; i++) {
+      size_t pos = b * 128 + i * 8;
+      W[i] =
+          ((uint64_t)input[pos] << 56) | ((uint64_t)input[pos + 1] << 48) |
+          ((uint64_t)input[pos + 2] << 40) | ((uint64_t)input[pos + 3] << 32) |
+          ((uint64_t)input[pos + 4] << 24) | ((uint64_t)input[pos + 5] << 16) |
+          ((uint64_t)input[pos + 6] << 8) | (uint64_t)input[pos + 7];
+    }
+    for (int i = 16; i < 80; i++) {
+      uint64_t s0 = rotr(W[i - 15], 1) ^ rotr(W[i - 15], 8) ^ (W[i - 15] >> 7);
+      uint64_t s1 = rotr(W[i - 2], 19) ^ rotr(W[i - 2], 61) ^ (W[i - 2] >> 6);
+      W[i] = W[i - 16] + s0 + W[i - 7] + s1;
+    }
+    uint64_t a = state[0], bb = state[1], c = state[2], d = state[3];
+    uint64_t e = state[4], f = state[5], g = state[6], h = state[7];
+    for (int i = 0; i < 80; i++) {
+      uint64_t S1 = rotr(e, 14) ^ rotr(e, 18) ^ rotr(e, 41);
+      uint64_t ch = (e & f) ^ (~e & g);
+      uint64_t T1 = h + S1 + ch + K512[i] + W[i];
+      uint64_t S0 = rotr(a, 28) ^ rotr(a, 34) ^ rotr(a, 39);
+      uint64_t maj = (a & bb) ^ (a & c) ^ (bb & c);
+      uint64_t T2 = S0 + maj;
+      h = g;
+      g = f;
+      f = e;
+      e = d + T1;
+      d = c;
+      c = bb;
+      bb = a;
+      a = T1 + T2;
+    }
+    state[0] += a;
+    state[1] += bb;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    state[5] += f;
+    state[6] += g;
+    state[7] += h;
+  }
+
+  uint8_t padded[256] = {0};
+  size_t remaining = len % 128;
+  size_t pad_blocks = (remaining < 112) ? 1 : 2;
+  for (size_t i = 0; i < remaining; i++)
+    padded[i] = input[num_blocks * 128 + i];
+  padded[remaining] = 0x80;
+  uint64_t bit_len = len * 8;
+  size_t len_offset = (pad_blocks == 1) ? 112 : 240;
+  for (int i = 0; i < 8; i++)
+    padded[len_offset + i] = 0;
+  for (int i = 0; i < 8; i++)
+    padded[len_offset + 8 + i] = (bit_len >> (56 - i * 8)) & 0xff;
+
+  for (size_t p = 0; p < pad_blocks; p++) {
+    uint64_t W[80];
+    for (int i = 0; i < 16; i++) {
+      W[i] = ((uint64_t)padded[p * 128 + i * 8] << 56) |
+             ((uint64_t)padded[p * 128 + i * 8 + 1] << 48) |
+             ((uint64_t)padded[p * 128 + i * 8 + 2] << 40) |
+             ((uint64_t)padded[p * 128 + i * 8 + 3] << 32) |
+             ((uint64_t)padded[p * 128 + i * 8 + 4] << 24) |
+             ((uint64_t)padded[p * 128 + i * 8 + 5] << 16) |
+             ((uint64_t)padded[p * 128 + i * 8 + 6] << 8) |
+             (uint64_t)padded[p * 128 + i * 8 + 7];
+    }
+    for (int i = 16; i < 80; i++) {
+      uint64_t s0 = rotr(W[i - 15], 1) ^ rotr(W[i - 15], 8) ^ (W[i - 15] >> 7);
+      uint64_t s1 = rotr(W[i - 2], 19) ^ rotr(W[i - 2], 61) ^ (W[i - 2] >> 6);
+      W[i] = W[i - 16] + s0 + W[i - 7] + s1;
+    }
+    uint64_t a = state[0], bb = state[1], c = state[2], d = state[3];
+    uint64_t e = state[4], f = state[5], g = state[6], h = state[7];
+    for (int i = 0; i < 80; i++) {
+      uint64_t S1 = rotr(e, 14) ^ rotr(e, 18) ^ rotr(e, 41);
+      uint64_t ch = (e & f) ^ (~e & g);
+      uint64_t T1 = h + S1 + ch + K512[i] + W[i];
+      uint64_t S0 = rotr(a, 28) ^ rotr(a, 34) ^ rotr(a, 39);
+      uint64_t maj = (a & bb) ^ (a & c) ^ (bb & c);
+      uint64_t T2 = S0 + maj;
+      h = g;
+      g = f;
+      f = e;
+      e = d + T1;
+      d = c;
+      c = bb;
+      bb = a;
+      a = T1 + T2;
+    }
+    state[0] += a;
+    state[1] += bb;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    state[5] += f;
+    state[6] += g;
+    state[7] += h;
+  }
+
+  size_t out_words = is_sha384 ? 6 : 8;
+  for (size_t i = 0; i < out_words; i++) {
+    output[i * 8] = (state[i] >> 56) & 0xff;
+    output[i * 8 + 1] = (state[i] >> 48) & 0xff;
+    output[i * 8 + 2] = (state[i] >> 40) & 0xff;
+    output[i * 8 + 3] = (state[i] >> 32) & 0xff;
+    output[i * 8 + 4] = (state[i] >> 24) & 0xff;
+    output[i * 8 + 5] = (state[i] >> 16) & 0xff;
+    output[i * 8 + 6] = (state[i] >> 8) & 0xff;
+    output[i * 8 + 7] = state[i] & 0xff;
+  }
 }
 
-// ============================================================================
-// C API Implementation
-// ============================================================================
+// GPU SHA-256 with local memory and vectorized loads
+void gpu_sha256_batch_optimized(GpuHashContext *ctx, const uint8_t *input,
+                                const uint64_t *offsets,
+                                const uint64_t *lengths, uint8_t *output,
+                                size_t num_messages) {
+  sycl::queue &q = ctx->queue;
 
-unsafe extern "C" {
+  size_t total_input = 1;
+  for (size_t i = 0; i < num_messages; i++) {
+    total_input = std::max(total_input, (size_t)(offsets[i] + lengths[i]));
+  }
+
+  // Allocate device memory
+  uint8_t *d_input = sycl::malloc_device<uint8_t>(total_input, q);
+  uint64_t *d_offsets = sycl::malloc_device<uint64_t>(num_messages, q);
+  uint64_t *d_lengths = sycl::malloc_device<uint64_t>(num_messages, q);
+  uint8_t *d_output = sycl::malloc_device<uint8_t>(num_messages * 32, q);
+
+  // Copy input data
+  q.memcpy(d_input, input, total_input);
+  q.memcpy(d_offsets, offsets, num_messages * sizeof(uint64_t));
+  q.memcpy(d_lengths, lengths, num_messages * sizeof(uint64_t));
+  q.wait();
+
+  // Get pre-allocated constants
+  uint32_t *d_K = ctx->d_K256;
+  uint32_t *d_H = ctx->d_H256;
+
+  // Use work-groups with local memory for K constants
+  constexpr size_t WG_SIZE = 256;
+  size_t num_wg = (num_messages + WG_SIZE - 1) / WG_SIZE;
+
+  q.submit([&](sycl::handler &cgh) {
+     // Local memory for K constants (shared within work-group)
+     sycl::local_accessor<uint32_t, 1> local_K(sycl::range<1>(64), cgh);
+
+     cgh.parallel_for(
+         sycl::nd_range<1>(num_wg * WG_SIZE, WG_SIZE),
+         [=](sycl::nd_item<1> item) {
+           size_t gid = item.get_global_id(0);
+           size_t lid = item.get_local_id(0);
+
+           // Cooperatively load K constants into local memory
+           if (lid < 64) {
+             local_K[lid] = d_K[lid];
+           }
+           item.barrier(sycl::access::fence_space::local_space);
+
+           if (gid >= num_messages)
+             return;
+
+           uint64_t offset = d_offsets[gid];
+           uint64_t len = d_lengths[gid];
+
+           // Initialize state
+           uint32_t state[8];
+           for (int i = 0; i < 8; i++)
+             state[i] = d_H[i];
+
+           // Process complete 64-byte blocks
+           uint64_t num_blocks = len / 64;
+           for (uint64_t b = 0; b < num_blocks; b++) {
+             uint32_t W[64];
+
+             // Vectorized load: read 4 bytes at a time using uint32
+             const uint8_t *block_ptr = d_input + offset + b * 64;
+             for (int i = 0; i < 16; i++) {
+               // Big-endian load
+               uint32_t val = ((uint32_t)block_ptr[i * 4] << 24) |
+                              ((uint32_t)block_ptr[i * 4 + 1] << 16) |
+                              ((uint32_t)block_ptr[i * 4 + 2] << 8) |
+                              (uint32_t)block_ptr[i * 4 + 3];
+               W[i] = val;
+             }
+
+// Message schedule with optimized rotations
+#pragma unroll 4
+             for (int i = 16; i < 64; i++) {
+               uint32_t x = W[i - 15];
+               uint32_t s0 =
+                   ((x >> 7) | (x << 25)) ^ ((x >> 18) | (x << 14)) ^ (x >> 3);
+               x = W[i - 2];
+               uint32_t s1 = ((x >> 17) | (x << 15)) ^ ((x >> 19) | (x << 13)) ^
+                             (x >> 10);
+               W[i] = W[i - 16] + s0 + W[i - 7] + s1;
+             }
+
+             // Compression with unrolled rounds
+             uint32_t a = state[0], bb = state[1], c = state[2], d = state[3];
+             uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+
+#pragma unroll 8
+             for (int i = 0; i < 64; i++) {
+               uint32_t S1 = ((e >> 6) | (e << 26)) ^ ((e >> 11) | (e << 21)) ^
+                             ((e >> 25) | (e << 7));
+               uint32_t ch = (e & f) ^ (~e & g);
+               uint32_t T1 = h + S1 + ch + local_K[i] + W[i];
+               uint32_t S0 = ((a >> 2) | (a << 30)) ^ ((a >> 13) | (a << 19)) ^
+                             ((a >> 22) | (a << 10));
+               uint32_t maj = (a & bb) ^ (a & c) ^ (bb & c);
+               uint32_t T2 = S0 + maj;
+               h = g;
+               g = f;
+               f = e;
+               e = d + T1;
+               d = c;
+               c = bb;
+               bb = a;
+               a = T1 + T2;
+             }
+
+             state[0] += a;
+             state[1] += bb;
+             state[2] += c;
+             state[3] += d;
+             state[4] += e;
+             state[5] += f;
+             state[6] += g;
+             state[7] += h;
+           }
+
+           // Handle padding
+           uint8_t padded[128];
+#pragma unroll
+           for (int i = 0; i < 128; i++)
+             padded[i] = 0;
+
+           uint64_t remaining = len % 64;
+           uint32_t pad_blocks = (remaining < 56) ? 1 : 2;
+
+           for (uint64_t i = 0; i < remaining; i++) {
+             padded[i] = d_input[offset + num_blocks * 64 + i];
+           }
+           padded[remaining] = 0x80;
+
+           uint64_t bit_len = len * 8;
+           uint32_t len_off = (pad_blocks == 1) ? 56 : 120;
+           for (int i = 0; i < 8; i++) {
+             padded[len_off + i] = (bit_len >> (56 - i * 8)) & 0xff;
+           }
+
+           // Process padding blocks
+           for (uint32_t p = 0; p < pad_blocks; p++) {
+             uint32_t W[64];
+             for (int i = 0; i < 16; i++) {
+               W[i] = ((uint32_t)padded[p * 64 + i * 4] << 24) |
+                      ((uint32_t)padded[p * 64 + i * 4 + 1] << 16) |
+                      ((uint32_t)padded[p * 64 + i * 4 + 2] << 8) |
+                      (uint32_t)padded[p * 64 + i * 4 + 3];
+             }
+
+#pragma unroll 4
+             for (int i = 16; i < 64; i++) {
+               uint32_t x = W[i - 15];
+               uint32_t s0 =
+                   ((x >> 7) | (x << 25)) ^ ((x >> 18) | (x << 14)) ^ (x >> 3);
+               x = W[i - 2];
+               uint32_t s1 = ((x >> 17) | (x << 15)) ^ ((x >> 19) | (x << 13)) ^
+                             (x >> 10);
+               W[i] = W[i - 16] + s0 + W[i - 7] + s1;
+             }
+
+             uint32_t a = state[0], bb = state[1], c = state[2], d = state[3];
+             uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+
+#pragma unroll 8
+             for (int i = 0; i < 64; i++) {
+               uint32_t S1 = ((e >> 6) | (e << 26)) ^ ((e >> 11) | (e << 21)) ^
+                             ((e >> 25) | (e << 7));
+               uint32_t ch = (e & f) ^ (~e & g);
+               uint32_t T1 = h + S1 + ch + local_K[i] + W[i];
+               uint32_t S0 = ((a >> 2) | (a << 30)) ^ ((a >> 13) | (a << 19)) ^
+                             ((a >> 22) | (a << 10));
+               uint32_t maj = (a & bb) ^ (a & c) ^ (bb & c);
+               uint32_t T2 = S0 + maj;
+               h = g;
+               g = f;
+               f = e;
+               e = d + T1;
+               d = c;
+               c = bb;
+               bb = a;
+               a = T1 + T2;
+             }
+
+             state[0] += a;
+             state[1] += bb;
+             state[2] += c;
+             state[3] += d;
+             state[4] += e;
+             state[5] += f;
+             state[6] += g;
+             state[7] += h;
+           }
+
+           // Write output (vectorized)
+           size_t out_off = gid * 32;
+           for (int i = 0; i < 8; i++) {
+             d_output[out_off + i * 4] = (state[i] >> 24) & 0xff;
+             d_output[out_off + i * 4 + 1] = (state[i] >> 16) & 0xff;
+             d_output[out_off + i * 4 + 2] = (state[i] >> 8) & 0xff;
+             d_output[out_off + i * 4 + 3] = state[i] & 0xff;
+           }
+         });
+   }).wait();
+
+  // Copy results back
+  q.memcpy(output, d_output, num_messages * 32).wait();
+
+  // Free temporary buffers
+  sycl::free(d_input, q);
+  sycl::free(d_offsets, q);
+  sycl::free(d_lengths, q);
+  sycl::free(d_output, q);
+}
+
+// GPU SHA-512/384
+void gpu_sha512_batch_optimized(GpuHashContext *ctx, const uint8_t *input,
+                                const uint64_t *offsets,
+                                const uint64_t *lengths, uint8_t *output,
+                                size_t num_messages, bool is_sha384) {
+  sycl::queue &q = ctx->queue;
+
+  size_t total_input = 1;
+  for (size_t i = 0; i < num_messages; i++) {
+    total_input = std::max(total_input, (size_t)(offsets[i] + lengths[i]));
+  }
+
+  size_t out_size = is_sha384 ? 48 : 64;
+
+  uint8_t *d_input = sycl::malloc_device<uint8_t>(total_input, q);
+  uint64_t *d_offsets = sycl::malloc_device<uint64_t>(num_messages, q);
+  uint64_t *d_lengths = sycl::malloc_device<uint64_t>(num_messages, q);
+  uint8_t *d_output = sycl::malloc_device<uint8_t>(num_messages * out_size, q);
+
+  q.memcpy(d_input, input, total_input);
+  q.memcpy(d_offsets, offsets, num_messages * sizeof(uint64_t));
+  q.memcpy(d_lengths, lengths, num_messages * sizeof(uint64_t));
+  q.wait();
+
+  uint64_t *d_K = ctx->d_K512;
+  uint64_t *d_H = is_sha384 ? ctx->d_H384 : ctx->d_H512;
+  size_t output_words = is_sha384 ? 6 : 8;
+
+  constexpr size_t WG_SIZE =
+      128; // Smaller WG for SHA-512 due to more registers
+  size_t num_wg = (num_messages + WG_SIZE - 1) / WG_SIZE;
+
+  q.submit([&](sycl::handler &cgh) {
+     sycl::local_accessor<uint64_t, 1> local_K(sycl::range<1>(80), cgh);
+
+     cgh.parallel_for(
+         sycl::nd_range<1>(num_wg * WG_SIZE, WG_SIZE),
+         [=](sycl::nd_item<1> item) {
+           size_t gid = item.get_global_id(0);
+           size_t lid = item.get_local_id(0);
+
+           // Load K into local memory cooperatively
+           for (size_t i = lid; i < 80; i += WG_SIZE) {
+             local_K[i] = d_K[i];
+           }
+           item.barrier(sycl::access::fence_space::local_space);
+
+           if (gid >= num_messages)
+             return;
+
+           uint64_t offset = d_offsets[gid];
+           uint64_t len = d_lengths[gid];
+
+           uint64_t state[8];
+           for (int i = 0; i < 8; i++)
+             state[i] = d_H[i];
+
+           uint64_t num_blocks = len / 128;
+           for (uint64_t b = 0; b < num_blocks; b++) {
+             uint64_t W[80];
+             const uint8_t *block_ptr = d_input + offset + b * 128;
+
+             for (int i = 0; i < 16; i++) {
+               W[i] = ((uint64_t)block_ptr[i * 8] << 56) |
+                      ((uint64_t)block_ptr[i * 8 + 1] << 48) |
+                      ((uint64_t)block_ptr[i * 8 + 2] << 40) |
+                      ((uint64_t)block_ptr[i * 8 + 3] << 32) |
+                      ((uint64_t)block_ptr[i * 8 + 4] << 24) |
+                      ((uint64_t)block_ptr[i * 8 + 5] << 16) |
+                      ((uint64_t)block_ptr[i * 8 + 6] << 8) |
+                      (uint64_t)block_ptr[i * 8 + 7];
+             }
+
+#pragma unroll 4
+             for (int i = 16; i < 80; i++) {
+               uint64_t x = W[i - 15];
+               uint64_t s0 =
+                   ((x >> 1) | (x << 63)) ^ ((x >> 8) | (x << 56)) ^ (x >> 7);
+               x = W[i - 2];
+               uint64_t s1 =
+                   ((x >> 19) | (x << 45)) ^ ((x >> 61) | (x << 3)) ^ (x >> 6);
+               W[i] = W[i - 16] + s0 + W[i - 7] + s1;
+             }
+
+             uint64_t a = state[0], bb = state[1], c = state[2], d = state[3];
+             uint64_t e = state[4], f = state[5], g = state[6], h = state[7];
+
+#pragma unroll 8
+             for (int i = 0; i < 80; i++) {
+               uint64_t S1 = ((e >> 14) | (e << 50)) ^ ((e >> 18) | (e << 46)) ^
+                             ((e >> 41) | (e << 23));
+               uint64_t ch = (e & f) ^ (~e & g);
+               uint64_t T1 = h + S1 + ch + local_K[i] + W[i];
+               uint64_t S0 = ((a >> 28) | (a << 36)) ^ ((a >> 34) | (a << 30)) ^
+                             ((a >> 39) | (a << 25));
+               uint64_t maj = (a & bb) ^ (a & c) ^ (bb & c);
+               uint64_t T2 = S0 + maj;
+               h = g;
+               g = f;
+               f = e;
+               e = d + T1;
+               d = c;
+               c = bb;
+               bb = a;
+               a = T1 + T2;
+             }
+
+             state[0] += a;
+             state[1] += bb;
+             state[2] += c;
+             state[3] += d;
+             state[4] += e;
+             state[5] += f;
+             state[6] += g;
+             state[7] += h;
+           }
+
+           // Padding
+           uint8_t padded[256];
+           for (int i = 0; i < 256; i++)
+             padded[i] = 0;
+
+           uint64_t remaining = len % 128;
+           uint32_t pad_blocks = (remaining < 112) ? 1 : 2;
+
+           for (uint64_t i = 0; i < remaining; i++) {
+             padded[i] = d_input[offset + num_blocks * 128 + i];
+           }
+           padded[remaining] = 0x80;
+
+           uint64_t bit_len = len * 8;
+           uint32_t len_off = (pad_blocks == 1) ? 112 : 240;
+           for (int i = 0; i < 8; i++)
+             padded[len_off + i] = 0;
+           for (int i = 0; i < 8; i++)
+             padded[len_off + 8 + i] = (bit_len >> (56 - i * 8)) & 0xff;
+
+           for (uint32_t p = 0; p < pad_blocks; p++) {
+             uint64_t W[80];
+             for (int i = 0; i < 16; i++) {
+               W[i] = ((uint64_t)padded[p * 128 + i * 8] << 56) |
+                      ((uint64_t)padded[p * 128 + i * 8 + 1] << 48) |
+                      ((uint64_t)padded[p * 128 + i * 8 + 2] << 40) |
+                      ((uint64_t)padded[p * 128 + i * 8 + 3] << 32) |
+                      ((uint64_t)padded[p * 128 + i * 8 + 4] << 24) |
+                      ((uint64_t)padded[p * 128 + i * 8 + 5] << 16) |
+                      ((uint64_t)padded[p * 128 + i * 8 + 6] << 8) |
+                      (uint64_t)padded[p * 128 + i * 8 + 7];
+             }
+
+#pragma unroll 4
+             for (int i = 16; i < 80; i++) {
+               uint64_t x = W[i - 15];
+               uint64_t s0 =
+                   ((x >> 1) | (x << 63)) ^ ((x >> 8) | (x << 56)) ^ (x >> 7);
+               x = W[i - 2];
+               uint64_t s1 =
+                   ((x >> 19) | (x << 45)) ^ ((x >> 61) | (x << 3)) ^ (x >> 6);
+               W[i] = W[i - 16] + s0 + W[i - 7] + s1;
+             }
+
+             uint64_t a = state[0], bb = state[1], c = state[2], d = state[3];
+             uint64_t e = state[4], f = state[5], g = state[6], h = state[7];
+
+#pragma unroll 8
+             for (int i = 0; i < 80; i++) {
+               uint64_t S1 = ((e >> 14) | (e << 50)) ^ ((e >> 18) | (e << 46)) ^
+                             ((e >> 41) | (e << 23));
+               uint64_t ch = (e & f) ^ (~e & g);
+               uint64_t T1 = h + S1 + ch + local_K[i] + W[i];
+               uint64_t S0 = ((a >> 28) | (a << 36)) ^ ((a >> 34) | (a << 30)) ^
+                             ((a >> 39) | (a << 25));
+               uint64_t maj = (a & bb) ^ (a & c) ^ (bb & c);
+               uint64_t T2 = S0 + maj;
+               h = g;
+               g = f;
+               f = e;
+               e = d + T1;
+               d = c;
+               c = bb;
+               bb = a;
+               a = T1 + T2;
+             }
+
+             state[0] += a;
+             state[1] += bb;
+             state[2] += c;
+             state[3] += d;
+             state[4] += e;
+             state[5] += f;
+             state[6] += g;
+             state[7] += h;
+           }
+
+           size_t out_off = gid * out_size;
+           for (size_t i = 0; i < output_words; i++) {
+             d_output[out_off + i * 8] = (state[i] >> 56) & 0xff;
+             d_output[out_off + i * 8 + 1] = (state[i] >> 48) & 0xff;
+             d_output[out_off + i * 8 + 2] = (state[i] >> 40) & 0xff;
+             d_output[out_off + i * 8 + 3] = (state[i] >> 32) & 0xff;
+             d_output[out_off + i * 8 + 4] = (state[i] >> 24) & 0xff;
+             d_output[out_off + i * 8 + 5] = (state[i] >> 16) & 0xff;
+             d_output[out_off + i * 8 + 6] = (state[i] >> 8) & 0xff;
+             d_output[out_off + i * 8 + 7] = state[i] & 0xff;
+           }
+         });
+   }).wait();
+
+  q.memcpy(output, d_output, num_messages * out_size).wait();
+
+  sycl::free(d_input, q);
+  sycl::free(d_offsets, q);
+  sycl::free(d_lengths, q);
+  sycl::free(d_output, q);
+}
+
+extern "C" {
 
 GpuHashError gpu_hash_init(void) {
-    std::lock_guard<std::mutex> lock(g_init_mutex);
-    
-    if (g_initialized) {
-        return GPU_HASH_SUCCESS;
-    }
-    
-    try {
-        // Enumerate all GPU devices
-        auto platforms = sycl::platform::get_platforms();
-        for (const auto& platform : platforms) {
-            auto devices = platform.get_devices(sycl::info::device_type::gpu);
-            for (const auto& device : devices) {
-                g_devices.push_back(device);
-            }
+  std::lock_guard<std::mutex> lock(g_init_mutex);
+  if (g_initialized)
+    return GPU_HASH_SUCCESS;
+  try {
+    for (const auto &p : sycl::platform::get_platforms()) {
+      try {
+        for (const auto &d : p.get_devices(sycl::info::device_type::gpu)) {
+          g_devices.push_back(d);
         }
-        
-        g_initialized = true;
-        return GPU_HASH_SUCCESS;
-    } catch (const sycl::exception& e) {
-        g_last_error = std::string("SYCL initialization failed: ") + e.what();
-        return GPU_HASH_ERROR_NO_DEVICE;
-    } catch (const std::exception& e) {
-        g_last_error = std::string("Initialization failed: ") + e.what();
-        return GPU_HASH_ERROR_UNKNOWN;
+      } catch (...) {
+      }
     }
+    g_initialized = true;
+    return GPU_HASH_SUCCESS;
+  } catch (...) {
+    return GPU_HASH_ERROR_NO_DEVICE;
+  }
 }
 
 void gpu_hash_cleanup(void) {
-    std::lock_guard<std::mutex> lock(g_init_mutex);
-    g_devices.clear();
-    g_initialized = false;
+  std::lock_guard<std::mutex> lock(g_init_mutex);
+  g_devices.clear();
+  g_initialized = false;
 }
 
 int gpu_hash_is_available(void) {
-    if (!g_initialized) {
-        if (gpu_hash_init() != GPU_HASH_SUCCESS) {
-            return 0;
-        }
-    }
-    
-    // Check for Intel GPUs
-    for (const auto& device : g_devices) {
-        std::string vendor = device.get_info<sycl::info::device::vendor>();
-        std::transform(vendor.begin(), vendor.end(), vendor.begin(), ::tolower);
-        if (vendor.find("intel") != std::string::npos) {
-            return 1;
-        }
-    }
-    
-    return 0;
+  if (!g_initialized)
+    gpu_hash_init();
+  for (const auto &d : g_devices) {
+    std::string v = d.get_info<sycl::info::device::vendor>();
+    std::transform(v.begin(), v.end(), v.begin(), ::tolower);
+    if (v.find("intel") != std::string::npos)
+      return 1;
+  }
+  return 0;
 }
 
 int gpu_hash_get_device_count(void) {
-    if (!g_initialized) {
-        gpu_hash_init();
-    }
-    return static_cast<int>(g_devices.size());
+  if (!g_initialized)
+    gpu_hash_init();
+  return (int)g_devices.size();
 }
 
-GpuHashError gpu_hash_get_device_info(int device_index, GpuDeviceInfo* info) {
-    if (!g_initialized) {
-        gpu_hash_init();
-    }
-    
-    if (device_index < 0 || device_index >= static_cast<int>(g_devices.size())) {
-        g_last_error = "Invalid device index";
-        return GPU_HASH_ERROR_INVALID_INPUT;
-    }
-    
-    if (!info) {
-        g_last_error = "Null info pointer";
-        return GPU_HASH_ERROR_INVALID_INPUT;
-    }
-    
-    try {
-        const auto& device = g_devices[device_index];
-        
-        std::string name = device.get_info<sycl::info::device::name>();
-        std::string vendor = device.get_info<sycl::info::device::vendor>();
-        std::string driver = device.get_info<sycl::info::device::driver_version>();
-        
-        strncpy(info->name, name.c_str(), sizeof(info->name) - 1);
-        strncpy(info->vendor, vendor.c_str(), sizeof(info->vendor) - 1);
-        strncpy(info->driver_version, driver.c_str(), sizeof(info->driver_version) - 1);
-        
-        info->device_type = GPU_DEVICE_TYPE_GPU;
-        info->max_compute_units = device.get_info<sycl::info::device::max_compute_units>();
-        info->global_memory_size = device.get_info<sycl::info::device::global_mem_size>();
-        info->local_memory_size = device.get_info<sycl::info::device::local_mem_size>();
-        info->max_work_group_size = device.get_info<sycl::info::device::max_work_group_size>();
-        
-        std::string vendor_lower = vendor;
-        std::transform(vendor_lower.begin(), vendor_lower.end(), vendor_lower.begin(), ::tolower);
-        info->is_intel = (vendor_lower.find("intel") != std::string::npos) ? 1 : 0;
-        
-        std::string name_lower = name;
-        std::transform(name_lower.begin(), name_lower.end(), name_lower.begin(), ::tolower);
-        info->is_intel_xe = (info->is_intel && 
-            (name_lower.find("arc") != std::string::npos ||
-             name_lower.find("xe") != std::string::npos ||
-             name_lower.find("iris") != std::string::npos ||
-             name_lower.find("uhd") != std::string::npos)) ? 1 : 0;
-        
-        return GPU_HASH_SUCCESS;
-    } catch (const std::exception& e) {
-        g_last_error = e.what();
-        return GPU_HASH_ERROR_UNKNOWN;
-    }
+GpuHashError gpu_hash_get_device_info(int idx, GpuDeviceInfo *info) {
+  if (!g_initialized)
+    gpu_hash_init();
+  if (idx < 0 || idx >= (int)g_devices.size())
+    return GPU_HASH_ERROR_INVALID_INPUT;
+  const auto &d = g_devices[idx];
+  std::strncpy(info->name, d.get_info<sycl::info::device::name>().c_str(), 255);
+  std::strncpy(info->vendor, d.get_info<sycl::info::device::vendor>().c_str(),
+               255);
+  std::strncpy(info->driver_version,
+               d.get_info<sycl::info::device::driver_version>().c_str(), 63);
+  info->device_type = GPU_DEVICE_TYPE_GPU;
+  info->max_compute_units = d.get_info<sycl::info::device::max_compute_units>();
+  info->global_memory_size = d.get_info<sycl::info::device::global_mem_size>();
+  info->local_memory_size = d.get_info<sycl::info::device::local_mem_size>();
+  info->max_work_group_size =
+      d.get_info<sycl::info::device::max_work_group_size>();
+  std::string v = info->vendor;
+  std::transform(v.begin(), v.end(), v.begin(), ::tolower);
+  info->is_intel = (v.find("intel") != std::string::npos) ? 1 : 0;
+  std::string n = info->name;
+  std::transform(n.begin(), n.end(), n.begin(), ::tolower);
+  info->is_intel_xe = (info->is_intel && (n.find("arc") != std::string::npos ||
+                                          n.find("xe") != std::string::npos))
+                          ? 1
+                          : 0;
+  return GPU_HASH_SUCCESS;
 }
 
-GpuHashError gpu_hash_create_context(
-    GpuHashAlgorithm algorithm,
-    int device_index,
-    GpuHashContextHandle* handle
-) {
-    if (!g_initialized) {
-        GpuHashError err = gpu_hash_init();
-        if (err != GPU_HASH_SUCCESS) return err;
-    }
-    
-    if (!handle) {
-        g_last_error = "Null handle pointer";
-        return GPU_HASH_ERROR_INVALID_INPUT;
-    }
-    
-    if (algorithm < GPU_HASH_SHA256 || algorithm > GPU_HASH_SHA512) {
-        g_last_error = "Invalid algorithm";
-        return GPU_HASH_ERROR_INVALID_ALGORITHM;
-    }
-    
-    try {
-        sycl::device selected_device;
-        
-        if (device_index >= 0) {
-            if (device_index >= static_cast<int>(g_devices.size())) {
-                g_last_error = "Invalid device index";
-                return GPU_HASH_ERROR_INVALID_INPUT;
-            }
-            selected_device = g_devices[device_index];
-        } else {
-            // Auto-select best Intel GPU
-            bool found = false;
-            for (const auto& device : g_devices) {
-                std::string vendor = device.get_info<sycl::info::device::vendor>();
-                std::transform(vendor.begin(), vendor.end(), vendor.begin(), ::tolower);
-                if (vendor.find("intel") != std::string::npos) {
-                    selected_device = device;
-                    found = true;
-                    break;
-                }
-            }
-            
-            if (!found) {
-                if (g_devices.empty()) {
-                    g_last_error = "No GPU devices found";
-                    return GPU_HASH_ERROR_NO_DEVICE;
-                }
-                selected_device = g_devices[0];
-            }
+GpuHashError gpu_hash_create_context(GpuHashAlgorithm alg, int idx,
+                                     GpuHashContextHandle *handle) {
+  if (!g_initialized)
+    gpu_hash_init();
+  if (!handle)
+    return GPU_HASH_ERROR_INVALID_INPUT;
+  try {
+    sycl::device dev;
+    if (idx >= 0 && idx < (int)g_devices.size()) {
+      dev = g_devices[idx];
+    } else {
+      for (const auto &d : g_devices) {
+        std::string v = d.get_info<sycl::info::device::vendor>();
+        std::transform(v.begin(), v.end(), v.begin(), ::tolower);
+        if (v.find("intel") != std::string::npos) {
+          dev = d;
+          break;
         }
-        
-        sycl::queue q(selected_device, sycl::property::queue::in_order());
-        *handle = new GpuHashContext(algorithm, std::move(q));
-        
-        return GPU_HASH_SUCCESS;
-    } catch (const sycl::exception& e) {
-        g_last_error = std::string("SYCL error: ") + e.what();
-        return GPU_HASH_ERROR_KERNEL_EXECUTION;
-    } catch (const std::exception& e) {
-        g_last_error = e.what();
-        return GPU_HASH_ERROR_UNKNOWN;
+      }
     }
+    *handle = new GpuHashContext(alg, sycl::queue(dev));
+    return GPU_HASH_SUCCESS;
+  } catch (const std::exception &e) {
+    g_last_error = e.what();
+    return GPU_HASH_ERROR_NO_DEVICE;
+  }
 }
 
 void gpu_hash_destroy_context(GpuHashContextHandle handle) {
-    delete handle;
+  delete static_cast<GpuHashContext *>(handle);
 }
 
-GpuHashError gpu_hash_single(
-    GpuHashContextHandle handle,
-    const uint8_t* input,
-    size_t input_len,
-    uint8_t* output,
-    size_t* output_len
-) {
-    if (!handle) {
-        g_last_error = "Invalid context handle";
-        return GPU_HASH_ERROR_NOT_INITIALIZED;
-    }
-    
-    if (!output) {
-        g_last_error = "Null output buffer";
-        return GPU_HASH_ERROR_INVALID_INPUT;
-    }
-    
-    try {
-        // Allocate device memory
-        uint8_t* d_input = sycl::malloc_device<uint8_t>(std::max(input_len, (size_t)1), handle->queue);
-        uint64_t* d_offsets = sycl::malloc_device<uint64_t>(1, handle->queue);
-        uint64_t* d_lengths = sycl::malloc_device<uint64_t>(1, handle->queue);
-        uint8_t* d_output = sycl::malloc_device<uint8_t>(handle->output_size, handle->queue);
-        
-        if (!d_input || !d_offsets || !d_lengths || !d_output) {
-            sycl::free(d_input, handle->queue);
-            sycl::free(d_offsets, handle->queue);
-            sycl::free(d_lengths, handle->queue);
-            sycl::free(d_output, handle->queue);
-            g_last_error = "Failed to allocate device memory";
-            return GPU_HASH_ERROR_MEMORY_ALLOCATION;
-        }
-        
-        // Copy data to device
-        uint64_t offset = 0;
-        uint64_t length = input_len;
-        
-        if (input_len > 0) {
-            handle->queue.memcpy(d_input, input, input_len);
-        }
-        handle->queue.memcpy(d_offsets, &offset, sizeof(uint64_t));
-        handle->queue.memcpy(d_lengths, &length, sizeof(uint64_t));
-        handle->queue.wait();
-        
-        // Execute kernel
-        switch (handle->algorithm) {
-            case GPU_HASH_SHA256:
-                sha256_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, 1);
-                break;
-            case GPU_HASH_SHA384:
-                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, 1, true);
-                break;
-            case GPU_HASH_SHA512:
-                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, 1, false);
-                break;
-        }
-        
-        // Copy result back
-        handle->queue.memcpy(output, d_output, handle->output_size).wait();
-        
-        if (output_len) {
-            *output_len = handle->output_size;
-        }
-        
-        // Cleanup
-        sycl::free(d_input, handle->queue);
-        sycl::free(d_offsets, handle->queue);
-        sycl::free(d_lengths, handle->queue);
-        sycl::free(d_output, handle->queue);
-        
-        return GPU_HASH_SUCCESS;
-    } catch (const sycl::exception& e) {
-        g_last_error = std::string("SYCL error: ") + e.what();
-        return GPU_HASH_ERROR_KERNEL_EXECUTION;
-    } catch (const std::exception& e) {
-        g_last_error = e.what();
-        return GPU_HASH_ERROR_UNKNOWN;
-    }
+GpuHashError gpu_hash_single(GpuHashContextHandle handle, const uint8_t *input,
+                             size_t len, uint8_t *output, size_t *out_len) {
+  if (!handle || !output)
+    return GPU_HASH_ERROR_INVALID_INPUT;
+  auto *ctx = static_cast<GpuHashContext *>(handle);
+  switch (ctx->algorithm) {
+  case GPU_HASH_SHA256:
+    sha256_cpu(input, len, output);
+    break;
+  case GPU_HASH_SHA384:
+    sha512_cpu(input, len, output, true);
+    break;
+  case GPU_HASH_SHA512:
+    sha512_cpu(input, len, output, false);
+    break;
+  }
+  if (out_len)
+    *out_len = ctx->output_size;
+  return GPU_HASH_SUCCESS;
 }
 
-GpuHashError gpu_hash_batch(
-    GpuHashContextHandle handle,
-    const uint8_t** inputs,
-    const size_t* input_lens,
-    size_t num_inputs,
-    uint8_t** outputs,
-    size_t output_size
-) {
-    if (!handle || !inputs || !input_lens || !outputs) {
-        g_last_error = "Invalid parameters";
-        return GPU_HASH_ERROR_INVALID_INPUT;
+GpuHashError gpu_hash_batch(GpuHashContextHandle handle, const uint8_t **inputs,
+                            const size_t *lens, size_t num, uint8_t **outputs,
+                            size_t) {
+  if (!handle || !inputs || !lens || !outputs)
+    return GPU_HASH_ERROR_INVALID_INPUT;
+  if (num == 0)
+    return GPU_HASH_SUCCESS;
+
+  auto *ctx = static_cast<GpuHashContext *>(handle);
+
+  try {
+    std::vector<uint64_t> offsets(num), lengths(num);
+    size_t total = 0;
+    for (size_t i = 0; i < num; i++) {
+      offsets[i] = total;
+      lengths[i] = lens[i];
+      total += lens[i];
     }
-    
-    if (num_inputs == 0) {
-        return GPU_HASH_SUCCESS;
+
+    std::vector<uint8_t> concat(std::max(total, (size_t)1));
+    for (size_t i = 0; i < num; i++) {
+      if (lens[i])
+        std::memcpy(concat.data() + offsets[i], inputs[i], lens[i]);
     }
-    
-    try {
-        // Calculate total size and build offset array
-        std::vector<uint64_t> offsets(num_inputs);
-        std::vector<uint64_t> lengths(num_inputs);
-        size_t total_size = 0;
-        
-        for (size_t i = 0; i < num_inputs; i++) {
-            offsets[i] = total_size;
-            lengths[i] = input_lens[i];
-            total_size += input_lens[i];
+
+    std::vector<uint8_t> out(num * ctx->output_size);
+
+    if (num >= 4) {
+      switch (ctx->algorithm) {
+      case GPU_HASH_SHA256:
+        gpu_sha256_batch_optimized(ctx, concat.data(), offsets.data(),
+                                   lengths.data(), out.data(), num);
+        break;
+      case GPU_HASH_SHA384:
+        gpu_sha512_batch_optimized(ctx, concat.data(), offsets.data(),
+                                   lengths.data(), out.data(), num, true);
+        break;
+      case GPU_HASH_SHA512:
+        gpu_sha512_batch_optimized(ctx, concat.data(), offsets.data(),
+                                   lengths.data(), out.data(), num, false);
+        break;
+      }
+    } else {
+      for (size_t i = 0; i < num; i++) {
+        switch (ctx->algorithm) {
+        case GPU_HASH_SHA256:
+          sha256_cpu(inputs[i], lens[i], out.data() + i * 32);
+          break;
+        case GPU_HASH_SHA384:
+          sha512_cpu(inputs[i], lens[i], out.data() + i * 48, true);
+          break;
+        case GPU_HASH_SHA512:
+          sha512_cpu(inputs[i], lens[i], out.data() + i * 64, false);
+          break;
         }
-        
-        // Concatenate all inputs
-        std::vector<uint8_t> concatenated(std::max(total_size, (size_t)1));
-        for (size_t i = 0; i < num_inputs; i++) {
-            if (input_lens[i] > 0) {
-                std::memcpy(concatenated.data() + offsets[i], inputs[i], input_lens[i]);
-            }
-        }
-        
-        // Allocate device memory
-        uint8_t* d_input = sycl::malloc_device<uint8_t>(concatenated.size(), handle->queue);
-        uint64_t* d_offsets = sycl::malloc_device<uint64_t>(num_inputs, handle->queue);
-        uint64_t* d_lengths = sycl::malloc_device<uint64_t>(num_inputs, handle->queue);
-        uint8_t* d_output = sycl::malloc_device<uint8_t>(handle->output_size * num_inputs, handle->queue);
-        
-        // Copy to device
-        handle->queue.memcpy(d_input, concatenated.data(), concatenated.size());
-        handle->queue.memcpy(d_offsets, offsets.data(), num_inputs * sizeof(uint64_t));
-        handle->queue.memcpy(d_lengths, lengths.data(), num_inputs * sizeof(uint64_t));
-        handle->queue.wait();
-        
-        // Execute kernel
-        switch (handle->algorithm) {
-            case GPU_HASH_SHA256:
-                sha256_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_inputs);
-                break;
-            case GPU_HASH_SHA384:
-                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_inputs, true);
-                break;
-            case GPU_HASH_SHA512:
-                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_inputs, false);
-                break;
-        }
-        
-        // Copy results back
-        std::vector<uint8_t> all_outputs(handle->output_size * num_inputs);
-        handle->queue.memcpy(all_outputs.data(), d_output, all_outputs.size()).wait();
-        
-        for (size_t i = 0; i < num_inputs; i++) {
-            std::memcpy(outputs[i], all_outputs.data() + i * handle->output_size, handle->output_size);
-        }
-        
-        // Cleanup
-        sycl::free(d_input, handle->queue);
-        sycl::free(d_offsets, handle->queue);
-        sycl::free(d_lengths, handle->queue);
-        sycl::free(d_output, handle->queue);
-        
-        return GPU_HASH_SUCCESS;
-    } catch (const sycl::exception& e) {
-        g_last_error = std::string("SYCL error: ") + e.what();
-        return GPU_HASH_ERROR_KERNEL_EXECUTION;
-    } catch (const std::exception& e) {
-        g_last_error = e.what();
-        return GPU_HASH_ERROR_UNKNOWN;
+      }
     }
+
+    for (size_t i = 0; i < num; i++) {
+      std::memcpy(outputs[i], out.data() + i * ctx->output_size,
+                  ctx->output_size);
+    }
+    return GPU_HASH_SUCCESS;
+  } catch (const sycl::exception &e) {
+    g_last_error = e.what();
+    return GPU_HASH_ERROR_KERNEL_EXECUTION;
+  }
 }
 
-GpuHashError gpu_hash_batch_fixed(
-    GpuHashContextHandle handle,
-    const uint8_t* input,
-    size_t message_size,
-    size_t num_messages,
-    uint8_t* output
-) {
-    if (!handle || !input || !output) {
-        g_last_error = "Invalid parameters";
-        return GPU_HASH_ERROR_INVALID_INPUT;
-    }
-    
-    // Build offset/length arrays for fixed-size messages
-    std::vector<uint64_t> offsets(num_messages);
-    std::vector<uint64_t> lengths(num_messages, message_size);
-    
-    for (size_t i = 0; i < num_messages; i++) {
-        offsets[i] = i * message_size;
-    }
-    
-    try {
-        size_t total_size = message_size * num_messages;
-        
-        uint8_t* d_input = sycl::malloc_device<uint8_t>(std::max(total_size, (size_t)1), handle->queue);
-        uint64_t* d_offsets = sycl::malloc_device<uint64_t>(num_messages, handle->queue);
-        uint64_t* d_lengths = sycl::malloc_device<uint64_t>(num_messages, handle->queue);
-        uint8_t* d_output = sycl::malloc_device<uint8_t>(handle->output_size * num_messages, handle->queue);
-        
-        if (total_size > 0) {
-            handle->queue.memcpy(d_input, input, total_size);
+GpuHashError gpu_hash_batch_fixed(GpuHashContextHandle handle,
+                                  const uint8_t *input, size_t msg_size,
+                                  size_t num, uint8_t *output) {
+  if (!handle || !input || !output)
+    return GPU_HASH_ERROR_INVALID_INPUT;
+  if (num == 0)
+    return GPU_HASH_SUCCESS;
+
+  auto *ctx = static_cast<GpuHashContext *>(handle);
+
+  std::vector<uint64_t> offsets(num), lengths(num, msg_size);
+  for (size_t i = 0; i < num; i++)
+    offsets[i] = i * msg_size;
+
+  try {
+    if (num >= 4) {
+      switch (ctx->algorithm) {
+      case GPU_HASH_SHA256:
+        gpu_sha256_batch_optimized(ctx, input, offsets.data(), lengths.data(),
+                                   output, num);
+        break;
+      case GPU_HASH_SHA384:
+        gpu_sha512_batch_optimized(ctx, input, offsets.data(), lengths.data(),
+                                   output, num, true);
+        break;
+      case GPU_HASH_SHA512:
+        gpu_sha512_batch_optimized(ctx, input, offsets.data(), lengths.data(),
+                                   output, num, false);
+        break;
+      }
+    } else {
+      for (size_t i = 0; i < num; i++) {
+        switch (ctx->algorithm) {
+        case GPU_HASH_SHA256:
+          sha256_cpu(input + i * msg_size, msg_size, output + i * 32);
+          break;
+        case GPU_HASH_SHA384:
+          sha512_cpu(input + i * msg_size, msg_size, output + i * 48, true);
+          break;
+        case GPU_HASH_SHA512:
+          sha512_cpu(input + i * msg_size, msg_size, output + i * 64, false);
+          break;
         }
-        handle->queue.memcpy(d_offsets, offsets.data(), num_messages * sizeof(uint64_t));
-        handle->queue.memcpy(d_lengths, lengths.data(), num_messages * sizeof(uint64_t));
-        handle->queue.wait();
-        
-        switch (handle->algorithm) {
-            case GPU_HASH_SHA256:
-                sha256_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_messages);
-                break;
-            case GPU_HASH_SHA384:
-                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_messages, true);
-                break;
-            case GPU_HASH_SHA512:
-                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_messages, false);
-                break;
-        }
-        
-        handle->queue.memcpy(output, d_output, handle->output_size * num_messages).wait();
-        
-        sycl::free(d_input, handle->queue);
-        sycl::free(d_offsets, handle->queue);
-        sycl::free(d_lengths, handle->queue);
-        sycl::free(d_output, handle->queue);
-        
-        return GPU_HASH_SUCCESS;
-    } catch (const sycl::exception& e) {
-        g_last_error = std::string("SYCL error: ") + e.what();
-        return GPU_HASH_ERROR_KERNEL_EXECUTION;
-    } catch (const std::exception& e) {
-        g_last_error = e.what();
-        return GPU_HASH_ERROR_UNKNOWN;
+      }
     }
+    return GPU_HASH_SUCCESS;
+  } catch (const sycl::exception &e) {
+    g_last_error = e.what();
+    return GPU_HASH_ERROR_KERNEL_EXECUTION;
+  }
 }
 
-size_t gpu_hash_output_size(GpuHashAlgorithm algorithm) {
-    switch (algorithm) {
-        case GPU_HASH_SHA256: return 32;
-        case GPU_HASH_SHA384: return 48;
-        case GPU_HASH_SHA512: return 64;
-        default: return 0;
-    }
+size_t gpu_hash_output_size(GpuHashAlgorithm alg) {
+  return (alg == GPU_HASH_SHA256) ? 32 : (alg == GPU_HASH_SHA384) ? 48 : 64;
 }
 
-const char* gpu_hash_get_last_error(void) {
-    return g_last_error.c_str();
+const char *gpu_hash_get_last_error(void) { return g_last_error.c_str(); }
 }
-
-} // extern "C"

--- a/src/gpu/sycl/gpu_hash.cpp
+++ b/src/gpu/sycl/gpu_hash.cpp
@@ -1,0 +1,838 @@
+/**
+ * @file gpu_hash.cpp
+ * @brief SYCL implementation of GPU-accelerated hashing for Intel Xe GPUs
+ * 
+ * This file implements SHA-256, SHA-384, and SHA-512 hashing using Intel SYCL.
+ * Optimized for Intel Arc, Iris Xe, and UHD Graphics.
+ * 
+ * Compile with:
+ *   icpx -fsycl -shared -fPIC -O3 -o libgpu_hash.so gpu_hash.cpp
+ * 
+ * Or for specific Intel GPU targets:
+ *   icpx -fsycl -fsycl-targets=intel_gpu_pvc,intel_gpu_dg2 -shared -fPIC -O3 -o libgpu_hash.so gpu_hash.cpp
+ */
+
+#include "gpu_hash.h"
+#include <sycl/sycl.hpp>
+#include <vector>
+#include <memory>
+#include <mutex>
+#include <cstring>
+#include <algorithm>
+
+// ============================================================================
+// SHA-256 Constants and Functions
+// ============================================================================
+
+namespace {
+
+// SHA-256 round constants
+constexpr uint32_t K256[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+// SHA-256 initial hash values
+constexpr uint32_t H256_INIT[8] = {
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+};
+
+// SHA-512 round constants
+constexpr uint64_t K512[80] = {
+    0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
+    0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL, 0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL,
+    0xd807aa98a3030242ULL, 0x12835b0145706fbeULL, 0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL,
+    0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL, 0x9bdc06a725c71235ULL, 0xc19bf174cf692694ULL,
+    0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL, 0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
+    0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL, 0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL,
+    0x983e5152ee66dfabULL, 0xa831c66d2db43210ULL, 0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL,
+    0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL, 0x06ca6351e003826fULL, 0x142929670a0e6e70ULL,
+    0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL, 0x4d2c6dfc5ac42aedULL, 0x53380d139d95b3dfULL,
+    0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL, 0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
+    0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL, 0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL,
+    0xd192e819d6ef5218ULL, 0xd69906245565a910ULL, 0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL,
+    0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL, 0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL,
+    0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL, 0x5b9cca4f7763e373ULL, 0x682e6ff3d6b2b8a3ULL,
+    0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL, 0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
+    0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL, 0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL,
+    0xca273eceea26619cULL, 0xd186b8c721c0c207ULL, 0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL,
+    0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL, 0x113f9804bef90daeULL, 0x1b710b35131c471bULL,
+    0x28db77f523047d84ULL, 0x32caab7b40c72493ULL, 0x3c9ebe0a15c9bebcULL, 0x431d67c49c100d4cULL,
+    0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL, 0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
+};
+
+// SHA-512 initial values
+constexpr uint64_t H512_INIT[8] = {
+    0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
+    0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL, 0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
+};
+
+// SHA-384 initial values
+constexpr uint64_t H384_INIT[8] = {
+    0xcbbb9d5dc1059ed8ULL, 0x629a292a367cd507ULL, 0x9159015a3070dd17ULL, 0x152fecd8f70e5939ULL,
+    0x67332667ffc00b31ULL, 0x8eb44a8768581511ULL, 0xdb0c2e0d64f98fa7ULL, 0x47b5481dbefa4fa4ULL
+};
+
+// Bitwise operations
+inline uint32_t rotr32(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
+inline uint64_t rotr64(uint64_t x, int n) { return (x >> n) | (x << (64 - n)); }
+
+// SHA-256 functions
+inline uint32_t ch32(uint32_t x, uint32_t y, uint32_t z) { return (x & y) ^ (~x & z); }
+inline uint32_t maj32(uint32_t x, uint32_t y, uint32_t z) { return (x & y) ^ (x & z) ^ (y & z); }
+inline uint32_t sigma0_256(uint32_t x) { return rotr32(x, 2) ^ rotr32(x, 13) ^ rotr32(x, 22); }
+inline uint32_t sigma1_256(uint32_t x) { return rotr32(x, 6) ^ rotr32(x, 11) ^ rotr32(x, 25); }
+inline uint32_t gamma0_256(uint32_t x) { return rotr32(x, 7) ^ rotr32(x, 18) ^ (x >> 3); }
+inline uint32_t gamma1_256(uint32_t x) { return rotr32(x, 17) ^ rotr32(x, 19) ^ (x >> 10); }
+
+// SHA-512 functions
+inline uint64_t ch64(uint64_t x, uint64_t y, uint64_t z) { return (x & y) ^ (~x & z); }
+inline uint64_t maj64(uint64_t x, uint64_t y, uint64_t z) { return (x & y) ^ (x & z) ^ (y & z); }
+inline uint64_t sigma0_512(uint64_t x) { return rotr64(x, 28) ^ rotr64(x, 34) ^ rotr64(x, 39); }
+inline uint64_t sigma1_512(uint64_t x) { return rotr64(x, 14) ^ rotr64(x, 18) ^ rotr64(x, 41); }
+inline uint64_t gamma0_512(uint64_t x) { return rotr64(x, 1) ^ rotr64(x, 8) ^ (x >> 7); }
+inline uint64_t gamma1_512(uint64_t x) { return rotr64(x, 19) ^ rotr64(x, 61) ^ (x >> 6); }
+
+// Thread-local error message
+thread_local std::string g_last_error;
+
+// Global state
+std::mutex g_init_mutex;
+bool g_initialized = false;
+std::vector<sycl::device> g_devices;
+
+} // anonymous namespace
+
+// ============================================================================
+// Hash Context Structure
+// ============================================================================
+
+struct GpuHashContext {
+    GpuHashAlgorithm algorithm;
+    sycl::queue queue;
+    size_t output_size;
+    
+    GpuHashContext(GpuHashAlgorithm alg, sycl::queue q)
+        : algorithm(alg), queue(std::move(q)) {
+        switch (alg) {
+            case GPU_HASH_SHA256: output_size = 32; break;
+            case GPU_HASH_SHA384: output_size = 48; break;
+            case GPU_HASH_SHA512: output_size = 64; break;
+            default: output_size = 32;
+        }
+    }
+};
+
+// ============================================================================
+// SYCL Kernels
+// ============================================================================
+
+// SHA-256 kernel for batch processing
+class Sha256BatchKernel;
+
+void sha256_hash_batch(
+    sycl::queue& q,
+    const uint8_t* input,
+    const uint64_t* offsets,
+    const uint64_t* lengths,
+    uint8_t* output,
+    size_t num_messages
+) {
+    // Copy constants to device
+    sycl::buffer<uint32_t, 1> k_buf(K256, sycl::range<1>(64));
+    sycl::buffer<uint32_t, 1> h_buf(H256_INIT, sycl::range<1>(8));
+    
+    q.submit([&](sycl::handler& h) {
+        auto k_acc = k_buf.get_access<sycl::access::mode::read>(h);
+        auto h_acc = h_buf.get_access<sycl::access::mode::read>(h);
+        
+        h.parallel_for<Sha256BatchKernel>(
+            sycl::range<1>(num_messages),
+            [=](sycl::id<1> idx) {
+                size_t msg_idx = idx[0];
+                uint64_t msg_offset = offsets[msg_idx];
+                uint64_t msg_len = lengths[msg_idx];
+                
+                // Initialize state
+                uint32_t state[8];
+                for (int i = 0; i < 8; i++) {
+                    state[i] = h_acc[i];
+                }
+                
+                // Process full blocks
+                uint64_t num_blocks = msg_len / 64;
+                for (uint64_t b = 0; b < num_blocks; b++) {
+                    uint32_t W[64];
+                    
+                    // Load block
+                    for (int i = 0; i < 16; i++) {
+                        uint64_t pos = msg_offset + b * 64 + i * 4;
+                        W[i] = ((uint32_t)input[pos] << 24) |
+                               ((uint32_t)input[pos + 1] << 16) |
+                               ((uint32_t)input[pos + 2] << 8) |
+                               (uint32_t)input[pos + 3];
+                    }
+                    
+                    // Extend
+                    for (int i = 16; i < 64; i++) {
+                        W[i] = gamma1_256(W[i-2]) + W[i-7] + gamma0_256(W[i-15]) + W[i-16];
+                    }
+                    
+                    // Compress
+                    uint32_t a = state[0], bb = state[1], c = state[2], d = state[3];
+                    uint32_t e = state[4], f = state[5], g = state[6], hh = state[7];
+                    
+                    for (int i = 0; i < 64; i++) {
+                        uint32_t T1 = hh + sigma1_256(e) + ch32(e, f, g) + k_acc[i] + W[i];
+                        uint32_t T2 = sigma0_256(a) + maj32(a, bb, c);
+                        hh = g; g = f; f = e; e = d + T1;
+                        d = c; c = bb; bb = a; a = T1 + T2;
+                    }
+                    
+                    state[0] += a; state[1] += bb; state[2] += c; state[3] += d;
+                    state[4] += e; state[5] += f; state[6] += g; state[7] += hh;
+                }
+                
+                // Handle padding
+                uint8_t padded[128] = {0};
+                uint32_t remaining = msg_len % 64;
+                uint32_t pad_blocks = (remaining < 56) ? 1 : 2;
+                
+                // Copy remaining bytes
+                for (uint32_t i = 0; i < remaining; i++) {
+                    padded[i] = input[msg_offset + num_blocks * 64 + i];
+                }
+                padded[remaining] = 0x80;
+                
+                // Add length
+                uint64_t bit_len = msg_len * 8;
+                uint32_t len_offset = (pad_blocks == 1) ? 56 : 120;
+                padded[len_offset] = (bit_len >> 56) & 0xff;
+                padded[len_offset + 1] = (bit_len >> 48) & 0xff;
+                padded[len_offset + 2] = (bit_len >> 40) & 0xff;
+                padded[len_offset + 3] = (bit_len >> 32) & 0xff;
+                padded[len_offset + 4] = (bit_len >> 24) & 0xff;
+                padded[len_offset + 5] = (bit_len >> 16) & 0xff;
+                padded[len_offset + 6] = (bit_len >> 8) & 0xff;
+                padded[len_offset + 7] = bit_len & 0xff;
+                
+                // Process padding blocks
+                for (uint32_t p = 0; p < pad_blocks; p++) {
+                    uint32_t W[64];
+                    for (int i = 0; i < 16; i++) {
+                        W[i] = ((uint32_t)padded[p * 64 + i * 4] << 24) |
+                               ((uint32_t)padded[p * 64 + i * 4 + 1] << 16) |
+                               ((uint32_t)padded[p * 64 + i * 4 + 2] << 8) |
+                               (uint32_t)padded[p * 64 + i * 4 + 3];
+                    }
+                    
+                    for (int i = 16; i < 64; i++) {
+                        W[i] = gamma1_256(W[i-2]) + W[i-7] + gamma0_256(W[i-15]) + W[i-16];
+                    }
+                    
+                    uint32_t a = state[0], bb = state[1], c = state[2], d = state[3];
+                    uint32_t e = state[4], f = state[5], g = state[6], hh = state[7];
+                    
+                    for (int i = 0; i < 64; i++) {
+                        uint32_t T1 = hh + sigma1_256(e) + ch32(e, f, g) + k_acc[i] + W[i];
+                        uint32_t T2 = sigma0_256(a) + maj32(a, bb, c);
+                        hh = g; g = f; f = e; e = d + T1;
+                        d = c; c = bb; bb = a; a = T1 + T2;
+                    }
+                    
+                    state[0] += a; state[1] += bb; state[2] += c; state[3] += d;
+                    state[4] += e; state[5] += f; state[6] += g; state[7] += hh;
+                }
+                
+                // Write output
+                size_t out_offset = msg_idx * 32;
+                for (int i = 0; i < 8; i++) {
+                    output[out_offset + i * 4] = (state[i] >> 24) & 0xff;
+                    output[out_offset + i * 4 + 1] = (state[i] >> 16) & 0xff;
+                    output[out_offset + i * 4 + 2] = (state[i] >> 8) & 0xff;
+                    output[out_offset + i * 4 + 3] = state[i] & 0xff;
+                }
+            }
+        );
+    }).wait();
+}
+
+// SHA-512/384 kernel
+class Sha512BatchKernel;
+
+void sha512_hash_batch(
+    sycl::queue& q,
+    const uint8_t* input,
+    const uint64_t* offsets,
+    const uint64_t* lengths,
+    uint8_t* output,
+    size_t num_messages,
+    bool is_sha384
+) {
+    sycl::buffer<uint64_t, 1> k_buf(K512, sycl::range<1>(80));
+    sycl::buffer<uint64_t, 1> h_buf(is_sha384 ? H384_INIT : H512_INIT, sycl::range<1>(8));
+    
+    size_t output_words = is_sha384 ? 6 : 8;
+    size_t output_bytes = is_sha384 ? 48 : 64;
+    
+    q.submit([&](sycl::handler& h) {
+        auto k_acc = k_buf.get_access<sycl::access::mode::read>(h);
+        auto h_acc = h_buf.get_access<sycl::access::mode::read>(h);
+        
+        h.parallel_for<Sha512BatchKernel>(
+            sycl::range<1>(num_messages),
+            [=](sycl::id<1> idx) {
+                size_t msg_idx = idx[0];
+                uint64_t msg_offset = offsets[msg_idx];
+                uint64_t msg_len = lengths[msg_idx];
+                
+                // Initialize state
+                uint64_t state[8];
+                for (int i = 0; i < 8; i++) {
+                    state[i] = h_acc[i];
+                }
+                
+                // Process full 128-byte blocks
+                uint64_t num_blocks = msg_len / 128;
+                for (uint64_t b = 0; b < num_blocks; b++) {
+                    uint64_t W[80];
+                    
+                    for (int i = 0; i < 16; i++) {
+                        uint64_t pos = msg_offset + b * 128 + i * 8;
+                        W[i] = ((uint64_t)input[pos] << 56) |
+                               ((uint64_t)input[pos + 1] << 48) |
+                               ((uint64_t)input[pos + 2] << 40) |
+                               ((uint64_t)input[pos + 3] << 32) |
+                               ((uint64_t)input[pos + 4] << 24) |
+                               ((uint64_t)input[pos + 5] << 16) |
+                               ((uint64_t)input[pos + 6] << 8) |
+                               (uint64_t)input[pos + 7];
+                    }
+                    
+                    for (int i = 16; i < 80; i++) {
+                        W[i] = gamma1_512(W[i-2]) + W[i-7] + gamma0_512(W[i-15]) + W[i-16];
+                    }
+                    
+                    uint64_t a = state[0], bb = state[1], c = state[2], d = state[3];
+                    uint64_t e = state[4], f = state[5], g = state[6], hh = state[7];
+                    
+                    for (int i = 0; i < 80; i++) {
+                        uint64_t T1 = hh + sigma1_512(e) + ch64(e, f, g) + k_acc[i] + W[i];
+                        uint64_t T2 = sigma0_512(a) + maj64(a, bb, c);
+                        hh = g; g = f; f = e; e = d + T1;
+                        d = c; c = bb; bb = a; a = T1 + T2;
+                    }
+                    
+                    state[0] += a; state[1] += bb; state[2] += c; state[3] += d;
+                    state[4] += e; state[5] += f; state[6] += g; state[7] += hh;
+                }
+                
+                // Handle padding
+                uint8_t padded[256] = {0};
+                uint64_t remaining = msg_len % 128;
+                uint32_t pad_blocks = (remaining < 112) ? 1 : 2;
+                
+                for (uint64_t i = 0; i < remaining; i++) {
+                    padded[i] = input[msg_offset + num_blocks * 128 + i];
+                }
+                padded[remaining] = 0x80;
+                
+                // Add 128-bit length (we only use lower 64 bits)
+                uint64_t bit_len = msg_len * 8;
+                uint32_t len_offset = (pad_blocks == 1) ? 112 : 240;
+                // Upper 64 bits = 0
+                for (int i = 0; i < 8; i++) padded[len_offset + i] = 0;
+                // Lower 64 bits
+                padded[len_offset + 8] = (bit_len >> 56) & 0xff;
+                padded[len_offset + 9] = (bit_len >> 48) & 0xff;
+                padded[len_offset + 10] = (bit_len >> 40) & 0xff;
+                padded[len_offset + 11] = (bit_len >> 32) & 0xff;
+                padded[len_offset + 12] = (bit_len >> 24) & 0xff;
+                padded[len_offset + 13] = (bit_len >> 16) & 0xff;
+                padded[len_offset + 14] = (bit_len >> 8) & 0xff;
+                padded[len_offset + 15] = bit_len & 0xff;
+                
+                for (uint32_t p = 0; p < pad_blocks; p++) {
+                    uint64_t W[80];
+                    for (int i = 0; i < 16; i++) {
+                        W[i] = ((uint64_t)padded[p * 128 + i * 8] << 56) |
+                               ((uint64_t)padded[p * 128 + i * 8 + 1] << 48) |
+                               ((uint64_t)padded[p * 128 + i * 8 + 2] << 40) |
+                               ((uint64_t)padded[p * 128 + i * 8 + 3] << 32) |
+                               ((uint64_t)padded[p * 128 + i * 8 + 4] << 24) |
+                               ((uint64_t)padded[p * 128 + i * 8 + 5] << 16) |
+                               ((uint64_t)padded[p * 128 + i * 8 + 6] << 8) |
+                               (uint64_t)padded[p * 128 + i * 8 + 7];
+                    }
+                    
+                    for (int i = 16; i < 80; i++) {
+                        W[i] = gamma1_512(W[i-2]) + W[i-7] + gamma0_512(W[i-15]) + W[i-16];
+                    }
+                    
+                    uint64_t a = state[0], bb = state[1], c = state[2], d = state[3];
+                    uint64_t e = state[4], f = state[5], g = state[6], hh = state[7];
+                    
+                    for (int i = 0; i < 80; i++) {
+                        uint64_t T1 = hh + sigma1_512(e) + ch64(e, f, g) + k_acc[i] + W[i];
+                        uint64_t T2 = sigma0_512(a) + maj64(a, bb, c);
+                        hh = g; g = f; f = e; e = d + T1;
+                        d = c; c = bb; bb = a; a = T1 + T2;
+                    }
+                    
+                    state[0] += a; state[1] += bb; state[2] += c; state[3] += d;
+                    state[4] += e; state[5] += f; state[6] += g; state[7] += hh;
+                }
+                
+                // Write output
+                size_t out_offset = msg_idx * output_bytes;
+                for (size_t i = 0; i < output_words; i++) {
+                    output[out_offset + i * 8] = (state[i] >> 56) & 0xff;
+                    output[out_offset + i * 8 + 1] = (state[i] >> 48) & 0xff;
+                    output[out_offset + i * 8 + 2] = (state[i] >> 40) & 0xff;
+                    output[out_offset + i * 8 + 3] = (state[i] >> 32) & 0xff;
+                    output[out_offset + i * 8 + 4] = (state[i] >> 24) & 0xff;
+                    output[out_offset + i * 8 + 5] = (state[i] >> 16) & 0xff;
+                    output[out_offset + i * 8 + 6] = (state[i] >> 8) & 0xff;
+                    output[out_offset + i * 8 + 7] = state[i] & 0xff;
+                }
+            }
+        );
+    }).wait();
+}
+
+// ============================================================================
+// C API Implementation
+// ============================================================================
+
+unsafe extern "C" {
+
+GpuHashError gpu_hash_init(void) {
+    std::lock_guard<std::mutex> lock(g_init_mutex);
+    
+    if (g_initialized) {
+        return GPU_HASH_SUCCESS;
+    }
+    
+    try {
+        // Enumerate all GPU devices
+        auto platforms = sycl::platform::get_platforms();
+        for (const auto& platform : platforms) {
+            auto devices = platform.get_devices(sycl::info::device_type::gpu);
+            for (const auto& device : devices) {
+                g_devices.push_back(device);
+            }
+        }
+        
+        g_initialized = true;
+        return GPU_HASH_SUCCESS;
+    } catch (const sycl::exception& e) {
+        g_last_error = std::string("SYCL initialization failed: ") + e.what();
+        return GPU_HASH_ERROR_NO_DEVICE;
+    } catch (const std::exception& e) {
+        g_last_error = std::string("Initialization failed: ") + e.what();
+        return GPU_HASH_ERROR_UNKNOWN;
+    }
+}
+
+void gpu_hash_cleanup(void) {
+    std::lock_guard<std::mutex> lock(g_init_mutex);
+    g_devices.clear();
+    g_initialized = false;
+}
+
+int gpu_hash_is_available(void) {
+    if (!g_initialized) {
+        if (gpu_hash_init() != GPU_HASH_SUCCESS) {
+            return 0;
+        }
+    }
+    
+    // Check for Intel GPUs
+    for (const auto& device : g_devices) {
+        std::string vendor = device.get_info<sycl::info::device::vendor>();
+        std::transform(vendor.begin(), vendor.end(), vendor.begin(), ::tolower);
+        if (vendor.find("intel") != std::string::npos) {
+            return 1;
+        }
+    }
+    
+    return 0;
+}
+
+int gpu_hash_get_device_count(void) {
+    if (!g_initialized) {
+        gpu_hash_init();
+    }
+    return static_cast<int>(g_devices.size());
+}
+
+GpuHashError gpu_hash_get_device_info(int device_index, GpuDeviceInfo* info) {
+    if (!g_initialized) {
+        gpu_hash_init();
+    }
+    
+    if (device_index < 0 || device_index >= static_cast<int>(g_devices.size())) {
+        g_last_error = "Invalid device index";
+        return GPU_HASH_ERROR_INVALID_INPUT;
+    }
+    
+    if (!info) {
+        g_last_error = "Null info pointer";
+        return GPU_HASH_ERROR_INVALID_INPUT;
+    }
+    
+    try {
+        const auto& device = g_devices[device_index];
+        
+        std::string name = device.get_info<sycl::info::device::name>();
+        std::string vendor = device.get_info<sycl::info::device::vendor>();
+        std::string driver = device.get_info<sycl::info::device::driver_version>();
+        
+        strncpy(info->name, name.c_str(), sizeof(info->name) - 1);
+        strncpy(info->vendor, vendor.c_str(), sizeof(info->vendor) - 1);
+        strncpy(info->driver_version, driver.c_str(), sizeof(info->driver_version) - 1);
+        
+        info->device_type = GPU_DEVICE_TYPE_GPU;
+        info->max_compute_units = device.get_info<sycl::info::device::max_compute_units>();
+        info->global_memory_size = device.get_info<sycl::info::device::global_mem_size>();
+        info->local_memory_size = device.get_info<sycl::info::device::local_mem_size>();
+        info->max_work_group_size = device.get_info<sycl::info::device::max_work_group_size>();
+        
+        std::string vendor_lower = vendor;
+        std::transform(vendor_lower.begin(), vendor_lower.end(), vendor_lower.begin(), ::tolower);
+        info->is_intel = (vendor_lower.find("intel") != std::string::npos) ? 1 : 0;
+        
+        std::string name_lower = name;
+        std::transform(name_lower.begin(), name_lower.end(), name_lower.begin(), ::tolower);
+        info->is_intel_xe = (info->is_intel && 
+            (name_lower.find("arc") != std::string::npos ||
+             name_lower.find("xe") != std::string::npos ||
+             name_lower.find("iris") != std::string::npos ||
+             name_lower.find("uhd") != std::string::npos)) ? 1 : 0;
+        
+        return GPU_HASH_SUCCESS;
+    } catch (const std::exception& e) {
+        g_last_error = e.what();
+        return GPU_HASH_ERROR_UNKNOWN;
+    }
+}
+
+GpuHashError gpu_hash_create_context(
+    GpuHashAlgorithm algorithm,
+    int device_index,
+    GpuHashContextHandle* handle
+) {
+    if (!g_initialized) {
+        GpuHashError err = gpu_hash_init();
+        if (err != GPU_HASH_SUCCESS) return err;
+    }
+    
+    if (!handle) {
+        g_last_error = "Null handle pointer";
+        return GPU_HASH_ERROR_INVALID_INPUT;
+    }
+    
+    if (algorithm < GPU_HASH_SHA256 || algorithm > GPU_HASH_SHA512) {
+        g_last_error = "Invalid algorithm";
+        return GPU_HASH_ERROR_INVALID_ALGORITHM;
+    }
+    
+    try {
+        sycl::device selected_device;
+        
+        if (device_index >= 0) {
+            if (device_index >= static_cast<int>(g_devices.size())) {
+                g_last_error = "Invalid device index";
+                return GPU_HASH_ERROR_INVALID_INPUT;
+            }
+            selected_device = g_devices[device_index];
+        } else {
+            // Auto-select best Intel GPU
+            bool found = false;
+            for (const auto& device : g_devices) {
+                std::string vendor = device.get_info<sycl::info::device::vendor>();
+                std::transform(vendor.begin(), vendor.end(), vendor.begin(), ::tolower);
+                if (vendor.find("intel") != std::string::npos) {
+                    selected_device = device;
+                    found = true;
+                    break;
+                }
+            }
+            
+            if (!found) {
+                if (g_devices.empty()) {
+                    g_last_error = "No GPU devices found";
+                    return GPU_HASH_ERROR_NO_DEVICE;
+                }
+                selected_device = g_devices[0];
+            }
+        }
+        
+        sycl::queue q(selected_device, sycl::property::queue::in_order());
+        *handle = new GpuHashContext(algorithm, std::move(q));
+        
+        return GPU_HASH_SUCCESS;
+    } catch (const sycl::exception& e) {
+        g_last_error = std::string("SYCL error: ") + e.what();
+        return GPU_HASH_ERROR_KERNEL_EXECUTION;
+    } catch (const std::exception& e) {
+        g_last_error = e.what();
+        return GPU_HASH_ERROR_UNKNOWN;
+    }
+}
+
+void gpu_hash_destroy_context(GpuHashContextHandle handle) {
+    delete handle;
+}
+
+GpuHashError gpu_hash_single(
+    GpuHashContextHandle handle,
+    const uint8_t* input,
+    size_t input_len,
+    uint8_t* output,
+    size_t* output_len
+) {
+    if (!handle) {
+        g_last_error = "Invalid context handle";
+        return GPU_HASH_ERROR_NOT_INITIALIZED;
+    }
+    
+    if (!output) {
+        g_last_error = "Null output buffer";
+        return GPU_HASH_ERROR_INVALID_INPUT;
+    }
+    
+    try {
+        // Allocate device memory
+        uint8_t* d_input = sycl::malloc_device<uint8_t>(std::max(input_len, (size_t)1), handle->queue);
+        uint64_t* d_offsets = sycl::malloc_device<uint64_t>(1, handle->queue);
+        uint64_t* d_lengths = sycl::malloc_device<uint64_t>(1, handle->queue);
+        uint8_t* d_output = sycl::malloc_device<uint8_t>(handle->output_size, handle->queue);
+        
+        if (!d_input || !d_offsets || !d_lengths || !d_output) {
+            sycl::free(d_input, handle->queue);
+            sycl::free(d_offsets, handle->queue);
+            sycl::free(d_lengths, handle->queue);
+            sycl::free(d_output, handle->queue);
+            g_last_error = "Failed to allocate device memory";
+            return GPU_HASH_ERROR_MEMORY_ALLOCATION;
+        }
+        
+        // Copy data to device
+        uint64_t offset = 0;
+        uint64_t length = input_len;
+        
+        if (input_len > 0) {
+            handle->queue.memcpy(d_input, input, input_len);
+        }
+        handle->queue.memcpy(d_offsets, &offset, sizeof(uint64_t));
+        handle->queue.memcpy(d_lengths, &length, sizeof(uint64_t));
+        handle->queue.wait();
+        
+        // Execute kernel
+        switch (handle->algorithm) {
+            case GPU_HASH_SHA256:
+                sha256_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, 1);
+                break;
+            case GPU_HASH_SHA384:
+                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, 1, true);
+                break;
+            case GPU_HASH_SHA512:
+                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, 1, false);
+                break;
+        }
+        
+        // Copy result back
+        handle->queue.memcpy(output, d_output, handle->output_size).wait();
+        
+        if (output_len) {
+            *output_len = handle->output_size;
+        }
+        
+        // Cleanup
+        sycl::free(d_input, handle->queue);
+        sycl::free(d_offsets, handle->queue);
+        sycl::free(d_lengths, handle->queue);
+        sycl::free(d_output, handle->queue);
+        
+        return GPU_HASH_SUCCESS;
+    } catch (const sycl::exception& e) {
+        g_last_error = std::string("SYCL error: ") + e.what();
+        return GPU_HASH_ERROR_KERNEL_EXECUTION;
+    } catch (const std::exception& e) {
+        g_last_error = e.what();
+        return GPU_HASH_ERROR_UNKNOWN;
+    }
+}
+
+GpuHashError gpu_hash_batch(
+    GpuHashContextHandle handle,
+    const uint8_t** inputs,
+    const size_t* input_lens,
+    size_t num_inputs,
+    uint8_t** outputs,
+    size_t output_size
+) {
+    if (!handle || !inputs || !input_lens || !outputs) {
+        g_last_error = "Invalid parameters";
+        return GPU_HASH_ERROR_INVALID_INPUT;
+    }
+    
+    if (num_inputs == 0) {
+        return GPU_HASH_SUCCESS;
+    }
+    
+    try {
+        // Calculate total size and build offset array
+        std::vector<uint64_t> offsets(num_inputs);
+        std::vector<uint64_t> lengths(num_inputs);
+        size_t total_size = 0;
+        
+        for (size_t i = 0; i < num_inputs; i++) {
+            offsets[i] = total_size;
+            lengths[i] = input_lens[i];
+            total_size += input_lens[i];
+        }
+        
+        // Concatenate all inputs
+        std::vector<uint8_t> concatenated(std::max(total_size, (size_t)1));
+        for (size_t i = 0; i < num_inputs; i++) {
+            if (input_lens[i] > 0) {
+                std::memcpy(concatenated.data() + offsets[i], inputs[i], input_lens[i]);
+            }
+        }
+        
+        // Allocate device memory
+        uint8_t* d_input = sycl::malloc_device<uint8_t>(concatenated.size(), handle->queue);
+        uint64_t* d_offsets = sycl::malloc_device<uint64_t>(num_inputs, handle->queue);
+        uint64_t* d_lengths = sycl::malloc_device<uint64_t>(num_inputs, handle->queue);
+        uint8_t* d_output = sycl::malloc_device<uint8_t>(handle->output_size * num_inputs, handle->queue);
+        
+        // Copy to device
+        handle->queue.memcpy(d_input, concatenated.data(), concatenated.size());
+        handle->queue.memcpy(d_offsets, offsets.data(), num_inputs * sizeof(uint64_t));
+        handle->queue.memcpy(d_lengths, lengths.data(), num_inputs * sizeof(uint64_t));
+        handle->queue.wait();
+        
+        // Execute kernel
+        switch (handle->algorithm) {
+            case GPU_HASH_SHA256:
+                sha256_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_inputs);
+                break;
+            case GPU_HASH_SHA384:
+                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_inputs, true);
+                break;
+            case GPU_HASH_SHA512:
+                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_inputs, false);
+                break;
+        }
+        
+        // Copy results back
+        std::vector<uint8_t> all_outputs(handle->output_size * num_inputs);
+        handle->queue.memcpy(all_outputs.data(), d_output, all_outputs.size()).wait();
+        
+        for (size_t i = 0; i < num_inputs; i++) {
+            std::memcpy(outputs[i], all_outputs.data() + i * handle->output_size, handle->output_size);
+        }
+        
+        // Cleanup
+        sycl::free(d_input, handle->queue);
+        sycl::free(d_offsets, handle->queue);
+        sycl::free(d_lengths, handle->queue);
+        sycl::free(d_output, handle->queue);
+        
+        return GPU_HASH_SUCCESS;
+    } catch (const sycl::exception& e) {
+        g_last_error = std::string("SYCL error: ") + e.what();
+        return GPU_HASH_ERROR_KERNEL_EXECUTION;
+    } catch (const std::exception& e) {
+        g_last_error = e.what();
+        return GPU_HASH_ERROR_UNKNOWN;
+    }
+}
+
+GpuHashError gpu_hash_batch_fixed(
+    GpuHashContextHandle handle,
+    const uint8_t* input,
+    size_t message_size,
+    size_t num_messages,
+    uint8_t* output
+) {
+    if (!handle || !input || !output) {
+        g_last_error = "Invalid parameters";
+        return GPU_HASH_ERROR_INVALID_INPUT;
+    }
+    
+    // Build offset/length arrays for fixed-size messages
+    std::vector<uint64_t> offsets(num_messages);
+    std::vector<uint64_t> lengths(num_messages, message_size);
+    
+    for (size_t i = 0; i < num_messages; i++) {
+        offsets[i] = i * message_size;
+    }
+    
+    try {
+        size_t total_size = message_size * num_messages;
+        
+        uint8_t* d_input = sycl::malloc_device<uint8_t>(std::max(total_size, (size_t)1), handle->queue);
+        uint64_t* d_offsets = sycl::malloc_device<uint64_t>(num_messages, handle->queue);
+        uint64_t* d_lengths = sycl::malloc_device<uint64_t>(num_messages, handle->queue);
+        uint8_t* d_output = sycl::malloc_device<uint8_t>(handle->output_size * num_messages, handle->queue);
+        
+        if (total_size > 0) {
+            handle->queue.memcpy(d_input, input, total_size);
+        }
+        handle->queue.memcpy(d_offsets, offsets.data(), num_messages * sizeof(uint64_t));
+        handle->queue.memcpy(d_lengths, lengths.data(), num_messages * sizeof(uint64_t));
+        handle->queue.wait();
+        
+        switch (handle->algorithm) {
+            case GPU_HASH_SHA256:
+                sha256_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_messages);
+                break;
+            case GPU_HASH_SHA384:
+                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_messages, true);
+                break;
+            case GPU_HASH_SHA512:
+                sha512_hash_batch(handle->queue, d_input, d_offsets, d_lengths, d_output, num_messages, false);
+                break;
+        }
+        
+        handle->queue.memcpy(output, d_output, handle->output_size * num_messages).wait();
+        
+        sycl::free(d_input, handle->queue);
+        sycl::free(d_offsets, handle->queue);
+        sycl::free(d_lengths, handle->queue);
+        sycl::free(d_output, handle->queue);
+        
+        return GPU_HASH_SUCCESS;
+    } catch (const sycl::exception& e) {
+        g_last_error = std::string("SYCL error: ") + e.what();
+        return GPU_HASH_ERROR_KERNEL_EXECUTION;
+    } catch (const std::exception& e) {
+        g_last_error = e.what();
+        return GPU_HASH_ERROR_UNKNOWN;
+    }
+}
+
+size_t gpu_hash_output_size(GpuHashAlgorithm algorithm) {
+    switch (algorithm) {
+        case GPU_HASH_SHA256: return 32;
+        case GPU_HASH_SHA384: return 48;
+        case GPU_HASH_SHA512: return 64;
+        default: return 0;
+    }
+}
+
+const char* gpu_hash_get_last_error(void) {
+    return g_last_error.c_str();
+}
+
+} // extern "C"

--- a/src/gpu/sycl/gpu_hash.h
+++ b/src/gpu/sycl/gpu_hash.h
@@ -1,18 +1,18 @@
 /**
  * @file gpu_hash.h
  * @brief C API for SYCL-based GPU hashing on Intel Xe GPUs
- * 
+ *
  * This header provides a C-compatible interface for GPU-accelerated
  * SHA-256, SHA-384, and SHA-512 hashing using Intel SYCL/oneAPI.
- * 
+ *
  * Compile with: icpx -fsycl -shared -fPIC -o libgpu_hash.so gpu_hash.cpp
  */
 
 #ifndef GPU_HASH_H
 #define GPU_HASH_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,59 +22,59 @@ extern "C" {
  * Hash algorithm identifiers
  */
 typedef enum {
-    GPU_HASH_SHA256 = 0,
-    GPU_HASH_SHA384 = 1,
-    GPU_HASH_SHA512 = 2
+  GPU_HASH_SHA256 = 0,
+  GPU_HASH_SHA384 = 1,
+  GPU_HASH_SHA512 = 2
 } GpuHashAlgorithm;
 
 /**
  * Error codes
  */
 typedef enum {
-    GPU_HASH_SUCCESS = 0,
-    GPU_HASH_ERROR_NO_DEVICE = 1,
-    GPU_HASH_ERROR_INVALID_ALGORITHM = 2,
-    GPU_HASH_ERROR_MEMORY_ALLOCATION = 3,
-    GPU_HASH_ERROR_KERNEL_EXECUTION = 4,
-    GPU_HASH_ERROR_INVALID_INPUT = 5,
-    GPU_HASH_ERROR_NOT_INITIALIZED = 6,
-    GPU_HASH_ERROR_UNKNOWN = 99
+  GPU_HASH_SUCCESS = 0,
+  GPU_HASH_ERROR_NO_DEVICE = 1,
+  GPU_HASH_ERROR_INVALID_ALGORITHM = 2,
+  GPU_HASH_ERROR_MEMORY_ALLOCATION = 3,
+  GPU_HASH_ERROR_KERNEL_EXECUTION = 4,
+  GPU_HASH_ERROR_INVALID_INPUT = 5,
+  GPU_HASH_ERROR_NOT_INITIALIZED = 6,
+  GPU_HASH_ERROR_UNKNOWN = 99
 } GpuHashError;
 
 /**
  * Device type
  */
 typedef enum {
-    GPU_DEVICE_TYPE_GPU = 0,
-    GPU_DEVICE_TYPE_CPU = 1,
-    GPU_DEVICE_TYPE_ACCELERATOR = 2
+  GPU_DEVICE_TYPE_GPU = 0,
+  GPU_DEVICE_TYPE_CPU = 1,
+  GPU_DEVICE_TYPE_ACCELERATOR = 2
 } GpuDeviceType;
 
 /**
  * Device information structure
  */
 typedef struct {
-    char name[256];
-    char vendor[256];
-    char driver_version[64];
-    GpuDeviceType device_type;
-    uint32_t max_compute_units;
-    uint64_t global_memory_size;
-    uint64_t local_memory_size;
-    size_t max_work_group_size;
-    int is_intel;
-    int is_intel_xe;
+  char name[256];
+  char vendor[256];
+  char driver_version[64];
+  GpuDeviceType device_type;
+  uint32_t max_compute_units;
+  uint64_t global_memory_size;
+  uint64_t local_memory_size;
+  size_t max_work_group_size;
+  int is_intel;
+  int is_intel_xe;
 } GpuDeviceInfo;
 
 /**
  * Opaque handle to GPU hasher context
  */
-typedef struct GpuHashContext* GpuHashContextHandle;
+typedef struct GpuHashContext *GpuHashContextHandle;
 
 /**
  * Initialize the GPU hashing library
  * Must be called before any other functions
- * 
+ *
  * @return GPU_HASH_SUCCESS on success, error code otherwise
  */
 GpuHashError gpu_hash_init(void);
@@ -87,51 +87,49 @@ void gpu_hash_cleanup(void);
 
 /**
  * Check if GPU hashing is available
- * 
+ *
  * @return 1 if available, 0 otherwise
  */
 int gpu_hash_is_available(void);
 
 /**
  * Get the number of available GPU devices
- * 
+ *
  * @return Number of devices
  */
 int gpu_hash_get_device_count(void);
 
 /**
  * Get information about a specific device
- * 
+ *
  * @param device_index Index of the device (0-based)
  * @param info Pointer to device info structure to fill
  * @return GPU_HASH_SUCCESS on success, error code otherwise
  */
-GpuHashError gpu_hash_get_device_info(int device_index, GpuDeviceInfo* info);
+GpuHashError gpu_hash_get_device_info(int device_index, GpuDeviceInfo *info);
 
 /**
  * Create a new hash context for a specific algorithm
- * 
+ *
  * @param algorithm The hash algorithm to use
  * @param device_index Device to use (-1 for auto-select best Intel GPU)
  * @param handle Pointer to receive the context handle
  * @return GPU_HASH_SUCCESS on success, error code otherwise
  */
-GpuHashError gpu_hash_create_context(
-    GpuHashAlgorithm algorithm,
-    int device_index,
-    GpuHashContextHandle* handle
-);
+GpuHashError gpu_hash_create_context(GpuHashAlgorithm algorithm,
+                                     int device_index,
+                                     GpuHashContextHandle *handle);
 
 /**
  * Destroy a hash context
- * 
+ *
  * @param handle The context handle to destroy
  */
 void gpu_hash_destroy_context(GpuHashContextHandle handle);
 
 /**
  * Hash a single message
- * 
+ *
  * @param handle The hash context
  * @param input Input data
  * @param input_len Length of input data
@@ -139,17 +137,13 @@ void gpu_hash_destroy_context(GpuHashContextHandle handle);
  * @param output_len Pointer to receive actual output length
  * @return GPU_HASH_SUCCESS on success, error code otherwise
  */
-GpuHashError gpu_hash_single(
-    GpuHashContextHandle handle,
-    const uint8_t* input,
-    size_t input_len,
-    uint8_t* output,
-    size_t* output_len
-);
+GpuHashError gpu_hash_single(GpuHashContextHandle handle, const uint8_t *input,
+                             size_t input_len, uint8_t *output,
+                             size_t *output_len);
 
 /**
  * Hash multiple messages in parallel (batch processing)
- * 
+ *
  * @param handle The hash context
  * @param inputs Array of input data pointers
  * @param input_lens Array of input lengths
@@ -158,19 +152,14 @@ GpuHashError gpu_hash_single(
  * @param output_size Size of each output buffer
  * @return GPU_HASH_SUCCESS on success, error code otherwise
  */
-GpuHashError gpu_hash_batch(
-    GpuHashContextHandle handle,
-    const uint8_t** inputs,
-    const size_t* input_lens,
-    size_t num_inputs,
-    uint8_t** outputs,
-    size_t output_size
-);
+GpuHashError gpu_hash_batch(GpuHashContextHandle handle, const uint8_t **inputs,
+                            const size_t *input_lens, size_t num_inputs,
+                            uint8_t **outputs, size_t output_size);
 
 /**
  * Hash contiguous data with multiple messages of same size
  * More efficient than gpu_hash_batch for fixed-size messages
- * 
+ *
  * @param handle The hash context
  * @param input Contiguous input data
  * @param message_size Size of each message
@@ -178,17 +167,13 @@ GpuHashError gpu_hash_batch(
  * @param output Output buffer (num_messages * hash_size bytes)
  * @return GPU_HASH_SUCCESS on success, error code otherwise
  */
-GpuHashError gpu_hash_batch_fixed(
-    GpuHashContextHandle handle,
-    const uint8_t* input,
-    size_t message_size,
-    size_t num_messages,
-    uint8_t* output
-);
+GpuHashError gpu_hash_batch_fixed(GpuHashContextHandle handle,
+                                  const uint8_t *input, size_t message_size,
+                                  size_t num_messages, uint8_t *output);
 
 /**
  * Get the output size for a hash algorithm
- * 
+ *
  * @param algorithm The hash algorithm
  * @return Output size in bytes (32 for SHA-256, 48 for SHA-384, 64 for SHA-512)
  */
@@ -196,10 +181,10 @@ size_t gpu_hash_output_size(GpuHashAlgorithm algorithm);
 
 /**
  * Get the last error message
- * 
+ *
  * @return Pointer to error message string (do not free)
  */
-const char* gpu_hash_get_last_error(void);
+const char *gpu_hash_get_last_error(void);
 
 #ifdef __cplusplus
 }

--- a/src/gpu/sycl/gpu_hash.h
+++ b/src/gpu/sycl/gpu_hash.h
@@ -1,0 +1,208 @@
+/**
+ * @file gpu_hash.h
+ * @brief C API for SYCL-based GPU hashing on Intel Xe GPUs
+ * 
+ * This header provides a C-compatible interface for GPU-accelerated
+ * SHA-256, SHA-384, and SHA-512 hashing using Intel SYCL/oneAPI.
+ * 
+ * Compile with: icpx -fsycl -shared -fPIC -o libgpu_hash.so gpu_hash.cpp
+ */
+
+#ifndef GPU_HASH_H
+#define GPU_HASH_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Hash algorithm identifiers
+ */
+typedef enum {
+    GPU_HASH_SHA256 = 0,
+    GPU_HASH_SHA384 = 1,
+    GPU_HASH_SHA512 = 2
+} GpuHashAlgorithm;
+
+/**
+ * Error codes
+ */
+typedef enum {
+    GPU_HASH_SUCCESS = 0,
+    GPU_HASH_ERROR_NO_DEVICE = 1,
+    GPU_HASH_ERROR_INVALID_ALGORITHM = 2,
+    GPU_HASH_ERROR_MEMORY_ALLOCATION = 3,
+    GPU_HASH_ERROR_KERNEL_EXECUTION = 4,
+    GPU_HASH_ERROR_INVALID_INPUT = 5,
+    GPU_HASH_ERROR_NOT_INITIALIZED = 6,
+    GPU_HASH_ERROR_UNKNOWN = 99
+} GpuHashError;
+
+/**
+ * Device type
+ */
+typedef enum {
+    GPU_DEVICE_TYPE_GPU = 0,
+    GPU_DEVICE_TYPE_CPU = 1,
+    GPU_DEVICE_TYPE_ACCELERATOR = 2
+} GpuDeviceType;
+
+/**
+ * Device information structure
+ */
+typedef struct {
+    char name[256];
+    char vendor[256];
+    char driver_version[64];
+    GpuDeviceType device_type;
+    uint32_t max_compute_units;
+    uint64_t global_memory_size;
+    uint64_t local_memory_size;
+    size_t max_work_group_size;
+    int is_intel;
+    int is_intel_xe;
+} GpuDeviceInfo;
+
+/**
+ * Opaque handle to GPU hasher context
+ */
+typedef struct GpuHashContext* GpuHashContextHandle;
+
+/**
+ * Initialize the GPU hashing library
+ * Must be called before any other functions
+ * 
+ * @return GPU_HASH_SUCCESS on success, error code otherwise
+ */
+GpuHashError gpu_hash_init(void);
+
+/**
+ * Cleanup the GPU hashing library
+ * Should be called when done using the library
+ */
+void gpu_hash_cleanup(void);
+
+/**
+ * Check if GPU hashing is available
+ * 
+ * @return 1 if available, 0 otherwise
+ */
+int gpu_hash_is_available(void);
+
+/**
+ * Get the number of available GPU devices
+ * 
+ * @return Number of devices
+ */
+int gpu_hash_get_device_count(void);
+
+/**
+ * Get information about a specific device
+ * 
+ * @param device_index Index of the device (0-based)
+ * @param info Pointer to device info structure to fill
+ * @return GPU_HASH_SUCCESS on success, error code otherwise
+ */
+GpuHashError gpu_hash_get_device_info(int device_index, GpuDeviceInfo* info);
+
+/**
+ * Create a new hash context for a specific algorithm
+ * 
+ * @param algorithm The hash algorithm to use
+ * @param device_index Device to use (-1 for auto-select best Intel GPU)
+ * @param handle Pointer to receive the context handle
+ * @return GPU_HASH_SUCCESS on success, error code otherwise
+ */
+GpuHashError gpu_hash_create_context(
+    GpuHashAlgorithm algorithm,
+    int device_index,
+    GpuHashContextHandle* handle
+);
+
+/**
+ * Destroy a hash context
+ * 
+ * @param handle The context handle to destroy
+ */
+void gpu_hash_destroy_context(GpuHashContextHandle handle);
+
+/**
+ * Hash a single message
+ * 
+ * @param handle The hash context
+ * @param input Input data
+ * @param input_len Length of input data
+ * @param output Output buffer (must be large enough for the hash)
+ * @param output_len Pointer to receive actual output length
+ * @return GPU_HASH_SUCCESS on success, error code otherwise
+ */
+GpuHashError gpu_hash_single(
+    GpuHashContextHandle handle,
+    const uint8_t* input,
+    size_t input_len,
+    uint8_t* output,
+    size_t* output_len
+);
+
+/**
+ * Hash multiple messages in parallel (batch processing)
+ * 
+ * @param handle The hash context
+ * @param inputs Array of input data pointers
+ * @param input_lens Array of input lengths
+ * @param num_inputs Number of inputs
+ * @param outputs Array of output buffers
+ * @param output_size Size of each output buffer
+ * @return GPU_HASH_SUCCESS on success, error code otherwise
+ */
+GpuHashError gpu_hash_batch(
+    GpuHashContextHandle handle,
+    const uint8_t** inputs,
+    const size_t* input_lens,
+    size_t num_inputs,
+    uint8_t** outputs,
+    size_t output_size
+);
+
+/**
+ * Hash contiguous data with multiple messages of same size
+ * More efficient than gpu_hash_batch for fixed-size messages
+ * 
+ * @param handle The hash context
+ * @param input Contiguous input data
+ * @param message_size Size of each message
+ * @param num_messages Number of messages
+ * @param output Output buffer (num_messages * hash_size bytes)
+ * @return GPU_HASH_SUCCESS on success, error code otherwise
+ */
+GpuHashError gpu_hash_batch_fixed(
+    GpuHashContextHandle handle,
+    const uint8_t* input,
+    size_t message_size,
+    size_t num_messages,
+    uint8_t* output
+);
+
+/**
+ * Get the output size for a hash algorithm
+ * 
+ * @param algorithm The hash algorithm
+ * @return Output size in bytes (32 for SHA-256, 48 for SHA-384, 64 for SHA-512)
+ */
+size_t gpu_hash_output_size(GpuHashAlgorithm algorithm);
+
+/**
+ * Get the last error message
+ * 
+ * @return Pointer to error message string (do not free)
+ */
+const char* gpu_hash_get_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPU_HASH_H */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,11 @@
 //! - **Manifests**: Complete C2PA manifests for ML assets
 //! - **Asset Types**: Support for various ML frameworks (TensorFlow, PyTorch, ONNX, etc.)
 //!
+//! ## Optional Features
+//!
+//! - **gpu-hashing**: GPU-accelerated hashing using Intel Xe GPUs via SYCL/oneAPI.
+//!   Enable with: `atlas-c2pa-lib = { version = "0.1", features = ["gpu-hashing"] }`
+//!
 //! ## Example: Creating a Model Manifest
 //!
 //! ```rust
@@ -37,6 +42,28 @@
 //! // Build the manifest
 //! let manifest = builder.build().unwrap();
 //! ```
+//!
+//! ## Example: GPU-Accelerated Hashing (requires `gpu-hashing` feature)
+//!
+//! ```rust,ignore
+//! use atlas_c2pa_lib::gpu::{GpuHasher, GpuHashAlgorithm, hash_auto};
+//!
+//! // Hash using GPU if available, CPU otherwise
+//! let hash = hash_auto(b"Hello, World!", GpuHashAlgorithm::Sha256)?;
+//! println!("Hash: {}", hex::encode(&hash));
+//!
+//! // Or create a hasher for multiple operations
+//! let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+//! let hash1 = hasher.hash(b"Message 1")?;
+//! let hash2 = hasher.hash(b"Message 2")?;
+//!
+//! // Batch hash multiple messages efficiently on GPU
+//! let messages = vec![b"Msg1".to_vec(), b"Msg2".to_vec(), b"Msg3".to_vec()];
+//! let hashes = hasher.hash_batch(&messages)?;
+//! ```
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod assertion;
 pub mod asset_type;
 pub mod cbor;
@@ -47,3 +74,262 @@ pub mod datetime_wrapper;
 pub mod ingredient;
 pub mod manifest;
 pub mod ml;
+
+/// GPU-accelerated hashing module (requires `gpu-hashing` feature)
+///
+/// This module provides GPU-accelerated hashing using Intel Xe GPUs via SYCL/oneAPI.
+/// It supports SHA-256, SHA-384, and SHA-512 algorithms.
+///
+/// ## Prerequisites
+///
+/// - Intel GPU (Arc, Iris Xe, UHD Graphics, or other Xe-based GPU)
+/// - Intel oneAPI Base Toolkit (for DPC++ compiler during build)
+/// - Intel GPU drivers with Level Zero support
+///
+/// ## Build Requirements
+///
+/// ```bash
+/// # Install Intel oneAPI compiler
+/// sudo apt install intel-oneapi-compiler-dpcpp-cpp
+///
+/// # Source the environment before building
+/// source /opt/intel/oneapi/setvars.sh
+///
+/// # Build with GPU support
+/// cargo build --features gpu-hashing
+/// ```
+///
+/// ## Example
+///
+/// ```rust,ignore
+/// use atlas_c2pa_lib::gpu::{GpuHasher, GpuHashAlgorithm, is_gpu_available};
+///
+/// if is_gpu_available() {
+///     let hasher = GpuHasher::new(GpuHashAlgorithm::Sha256)?;
+///     let hash = hasher.hash(b"Hello, World!")?;
+///     println!("GPU hash: {}", hex::encode(&hash));
+/// } else {
+///     println!("GPU not available, using CPU");
+/// }
+/// ```
+#[cfg(feature = "gpu-hashing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gpu-hashing")))]
+pub mod gpu;
+
+/// Hash utilities module
+///
+/// Provides convenient hashing functions that work regardless of GPU availability.
+pub mod hash {
+    use crate::cose::HashAlgorithm;
+
+    /// Compute a hash of the given data using the specified algorithm.
+    ///
+    /// This function uses CPU-based hashing via the ring crate.
+    /// For GPU-accelerated hashing, use the `gpu` module when the
+    /// `gpu-hashing` feature is enabled.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data to hash
+    /// * `algorithm` - The hash algorithm to use
+    ///
+    /// # Returns
+    ///
+    /// The hash as a byte vector
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_c2pa_lib::hash::compute_hash;
+    /// use atlas_c2pa_lib::cose::HashAlgorithm;
+    ///
+    /// let hash = compute_hash(b"Hello, World!", HashAlgorithm::Sha256);
+    /// assert_eq!(hash.len(), 32); // SHA-256 produces 32 bytes
+    /// ```
+    pub fn compute_hash(data: &[u8], algorithm: HashAlgorithm) -> Vec<u8> {
+        use ring::digest;
+
+        let algorithm = match algorithm {
+            HashAlgorithm::Sha256 => &digest::SHA256,
+            HashAlgorithm::Sha384 => &digest::SHA384,
+            HashAlgorithm::Sha512 => &digest::SHA512,
+        };
+
+        digest::digest(algorithm, data).as_ref().to_vec()
+    }
+
+    /// Compute a SHA-256 hash of the given data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_c2pa_lib::hash::sha256;
+    ///
+    /// let hash = sha256(b"Hello, World!");
+    /// assert_eq!(hash.len(), 32);
+    /// ```
+    pub fn sha256(data: &[u8]) -> Vec<u8> {
+        compute_hash(data, HashAlgorithm::Sha256)
+    }
+
+    /// Compute a SHA-384 hash of the given data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_c2pa_lib::hash::sha384;
+    ///
+    /// let hash = sha384(b"Hello, World!");
+    /// assert_eq!(hash.len(), 48);
+    /// ```
+    pub fn sha384(data: &[u8]) -> Vec<u8> {
+        compute_hash(data, HashAlgorithm::Sha384)
+    }
+
+    /// Compute a SHA-512 hash of the given data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_c2pa_lib::hash::sha512;
+    ///
+    /// let hash = sha512(b"Hello, World!");
+    /// assert_eq!(hash.len(), 64);
+    /// ```
+    pub fn sha512(data: &[u8]) -> Vec<u8> {
+        compute_hash(data, HashAlgorithm::Sha512)
+    }
+
+    /// Compute a hash and return it as a hex string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_c2pa_lib::hash::compute_hash_hex;
+    /// use atlas_c2pa_lib::cose::HashAlgorithm;
+    ///
+    /// let hash_hex = compute_hash_hex(b"Hello, World!", HashAlgorithm::Sha256);
+    /// assert_eq!(hash_hex.len(), 64); // 32 bytes = 64 hex chars
+    /// ```
+    pub fn compute_hash_hex(data: &[u8], algorithm: HashAlgorithm) -> String {
+        hex::encode(compute_hash(data, algorithm))
+    }
+
+    /// Compute a hash of a file.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use atlas_c2pa_lib::hash::hash_file;
+    /// use atlas_c2pa_lib::cose::HashAlgorithm;
+    /// use std::path::Path;
+    ///
+    /// let hash = hash_file(Path::new("model.onnx"), HashAlgorithm::Sha256)?;
+    /// println!("Model hash: {}", hex::encode(&hash));
+    /// ```
+    pub fn hash_file(
+        path: &std::path::Path,
+        algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, std::io::Error> {
+        use std::fs::File;
+        use std::io::Read;
+
+        let mut file = File::open(path)?;
+        let mut data = Vec::new();
+        file.read_to_end(&mut data)?;
+
+        Ok(compute_hash(&data, algorithm))
+    }
+
+    /// Verify that data matches an expected hash.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use atlas_c2pa_lib::hash::{sha256, verify_hash};
+    /// use atlas_c2pa_lib::cose::HashAlgorithm;
+    ///
+    /// let data = b"Hello, World!";
+    /// let expected_hash = sha256(data);
+    ///
+    /// assert!(verify_hash(data, &expected_hash, HashAlgorithm::Sha256));
+    /// ```
+    pub fn verify_hash(data: &[u8], expected: &[u8], algorithm: HashAlgorithm) -> bool {
+        let computed = compute_hash(data, algorithm);
+        computed == expected
+    }
+
+    /// GPU-accelerated hash computation (when available).
+    ///
+    /// This function automatically uses GPU hashing if available and the
+    /// `gpu-hashing` feature is enabled. Otherwise, it falls back to CPU.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use atlas_c2pa_lib::hash::compute_hash_auto;
+    /// use atlas_c2pa_lib::cose::HashAlgorithm;
+    ///
+    /// let hash = compute_hash_auto(b"Hello, World!", HashAlgorithm::Sha256)?;
+    /// ```
+    #[cfg(feature = "gpu-hashing")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "gpu-hashing")))]
+    pub fn compute_hash_auto(
+        data: &[u8],
+        algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, crate::gpu::GpuError> {
+        use crate::gpu::GpuHashAlgorithm;
+
+        let gpu_alg = match algorithm {
+            HashAlgorithm::Sha256 => GpuHashAlgorithm::Sha256,
+            HashAlgorithm::Sha384 => GpuHashAlgorithm::Sha384,
+            HashAlgorithm::Sha512 => GpuHashAlgorithm::Sha512,
+        };
+
+        crate::gpu::hash_auto(data, gpu_alg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_functions() {
+        let data = b"Hello, World!";
+
+        let sha256_hash = hash::sha256(data);
+        assert_eq!(sha256_hash.len(), 32);
+
+        let sha384_hash = hash::sha384(data);
+        assert_eq!(sha384_hash.len(), 48);
+
+        let sha512_hash = hash::sha512(data);
+        assert_eq!(sha512_hash.len(), 64);
+    }
+
+    #[test]
+    fn test_hash_verification() {
+        let data = b"Test data for verification";
+        let hash = hash::sha256(data);
+
+        assert!(hash::verify_hash(data, &hash, cose::HashAlgorithm::Sha256));
+        assert!(!hash::verify_hash(
+            b"Wrong data",
+            &hash,
+            cose::HashAlgorithm::Sha256
+        ));
+    }
+
+    #[test]
+    fn test_hash_hex() {
+        let data = b"";
+        let hash_hex = hash::compute_hash_hex(data, cose::HashAlgorithm::Sha256);
+
+        // SHA-256 of empty string
+        assert_eq!(
+            hash_hex,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces functionality to offload SHA-256 and SHA-512 hashing operations to Intel Xe graphics cards. Offloading these computations significantly improves hashing performance by leveraging GPU acceleration.
**Requirements**: Intel Xe graphics card is required for this feature. If no compatible Intel Xe GPU is detected, the library will automatically fail over to the CPU implementation.